### PR TITLE
fixing fomatting for deprecated terms

### DIFF
--- a/concepts/concept-3.1.5.1.yaml
+++ b/concepts/concept-3.1.5.1.yaml
@@ -8,13 +8,13 @@ eng:
     designation: application entity
   - type: expression
     designation: ITS-S application entity
+  - type: expression
+    normative_status: deprecated
+    designation: information layer
   definition:
-  - content: |-
-      deprecated:[information layer]
-
-
-
-      <ITS-S> part of the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture,ITS station reference architecture}} that is responsible for providing ITS-related functionality
+  - content: "<ITS-S> part of the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference
+      architecture,ITS station reference architecture}} that is responsible for providing
+      ITS-related functionality"
   notes:
   - content: Within the US, the National Transportation Communications for ITS Protocol
       (NTCIP) standards identify an "information layer" on top of the traditional

--- a/concepts/concept-3.1.5.5.yaml
+++ b/concepts/concept-3.1.5.5.yaml
@@ -8,13 +8,13 @@ eng:
     designation: facilities layer
   - type: expression
     designation: ITS-S facilities layer
+  - type: expression
+    normative_status: deprecated
+    designation: application layer
   definition:
-  - content: |-
-      deprecated:[application layer]
-
-
-
-      <ITS-S> protocol layer in the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture,ITS station reference architecture}} containing the OSI session, presentation and application layer protocols
+  - content: "<ITS-S> protocol layer in the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S
+      reference architecture,ITS station reference architecture}} containing the OSI
+      session, presentation and application layer protocols"
   notes:
   - content: Within the US, the NTCIP standards call the facilities layer the "application
       layer". However, as this term is easily confused with both the OSI application

--- a/concepts/concept-3.4.2.6.yaml
+++ b/concepts/concept-3.4.2.6.yaml
@@ -6,13 +6,12 @@ eng:
   - type: expression
     normative_status: preferred
     designation: geographic identifier
+  - type: expression
+    normative_status: deprecated
+    designation: location code
   definition:
-  - content: |-
-      deprecated:[location code]
-
-
-
-      {{urn:iso:std:iso:14812:3.4.2.2,spatial reference}} in the form of a label or code that identifies a {{urn:iso:std:iso:14812:3.4.1.1,location}}
+  - content: "{{urn:iso:std:iso:14812:3.4.2.2,spatial reference}} in the form of a
+      label or code that identifies a {{urn:iso:std:iso:14812:3.4.1.1,location}}"
   notes:
   - content: The term "location code" has been used previously in ISO/TC 204 documents,
       but "geographic identifier" is preferred to better align with the activities

--- a/concepts/concept-3.7.3.15.yaml
+++ b/concepts/concept-3.7.3.15.yaml
@@ -12,13 +12,11 @@ eng:
   - type: expression
     normative_status: admitted
     designation: AV
+  - type: expression
+    normative_status: deprecated
+    designation: autonomous vehicle
   definition:
-  - content: |-
-      deprecated:[autonomous vehicle]
-
-
-
-      {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} integrated with an {{urn:iso:std:iso:14812:3.7.3.10,ADS}}
+  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} integrated with an {{urn:iso:std:iso:14812:3.7.3.10,ADS}}"
   notes:
   - content: The terms "automated vehicle" and "AV" are often used in a colloquial
       form. However, these terms can be used to mean either an "ADS-equipped vehicle"


### PR DESCRIPTION
Fixing formatting for `deprecated` terms.

<img width="1440" alt="Screenshot 2022-08-19 at 5 57 31 PM" src="https://user-images.githubusercontent.com/5301572/185623448-82b8fe54-0e2d-4fb6-9e26-25f9fcdd7840.png">


closes #9 