### PR TITLE
fixing reference according to metanorma syntax

### DIFF
--- a/concepts/concept-3.1.1.1.yaml
+++ b/concepts/concept-3.1.1.1.yaml
@@ -11,7 +11,7 @@ eng:
       including associations among these things
   notes: []
   examples:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person,Person}}, object, event, idea,
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person,Person}}, object, event, idea,
       process, etc."
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.1.2.yaml
+++ b/concepts/concept-3.1.1.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: immaterial entity
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that does not occupy three-dimensional
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that does not occupy three-dimensional
       space"
   notes: []
   examples:

--- a/concepts/concept-3.1.1.3.yaml
+++ b/concepts/concept-3.1.1.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: material entity
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that occupies three-dimensional
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that occupies three-dimensional
       space"
   notes:
   - content: All material entities have certain characteristics that can be described

--- a/concepts/concept-3.1.1.4.yaml
+++ b/concepts/concept-3.1.1.4.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: non-biological entity
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.3,material entity}} that is not and has
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that is not and has
       never been a living organism"
   notes: []
   examples: []

--- a/concepts/concept-3.1.1.5.yaml
+++ b/concepts/concept-3.1.1.5.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: biological entity
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.3,material entity}} that was or is a living
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that was or is a living
       organism"
   notes: []
   examples: []

--- a/concepts/concept-3.1.1.6.yaml
+++ b/concepts/concept-3.1.1.6.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: person
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.5,biological entity}} that is a human
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.5>>,biological entity}} that is a human
       being"
   notes: []
   examples: []

--- a/concepts/concept-3.1.10.1.yaml
+++ b/concepts/concept-3.1.10.1.yaml
@@ -7,16 +7,16 @@ eng:
     normative_status: preferred
     designation: data concept
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.11.1,data element}}, {{urn:iso:std:iso:14812:3.1.11.2,class}},
-      {{urn:iso:std:iso:14812:3.1.11.3,value domain}}, {{urn:iso:std:iso:14812:3.1.11.4,data
-      frame}}, {{urn:iso:std:iso:14812:3.1.11.5,message}} or {{urn:iso:std:iso:14812:3.1.11.6,interface
+  - content: "{{<<urn:iso:std:iso:14812:3.1.11.1>>,data element}}, {{<<urn:iso:std:iso:14812:3.1.11.2>>,class}},
+      {{<<urn:iso:std:iso:14812:3.1.11.3>>,value domain}}, {{<<urn:iso:std:iso:14812:3.1.11.4>>,data
+      frame}}, {{<<urn:iso:std:iso:14812:3.1.11.5>>,message}} or {{<<urn:iso:std:iso:14812:3.1.11.6>>,interface
       dialogue}} defined, at a minimum, with an unambiguous identifier and a definition"
   notes:
   - content: In order to exchange a value corresponding to a data concept, more information
       than an identifier, a name and a definition can be needed. For a property, a
       data type is needed. Depending on the kind of property, other data elements
       such as unit of measure, and language, can be needed as well. The additional
-      information can be given in the {{urn:iso:std:iso:14812:3.1.10.3,data dictionary}},
+      information can be given in the {{<<urn:iso:std:iso:14812:3.1.10.3>>,data dictionary}},
       in a data specification that references the data concept or associated with
       the data themselves.
   examples: []

--- a/concepts/concept-3.1.10.2.yaml
+++ b/concepts/concept-3.1.10.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: meta-attribute
   definition:
-  - content: documenting characteristic of a {{urn:iso:std:iso:14812:3.1.10.1,data
-      concept}} that is stored in a {{urn:iso:std:iso:14812:3.1.10.3,data dictionary}}
+  - content: documenting characteristic of a {{<<urn:iso:std:iso:14812:3.1.10.1>>,data
+      concept}} that is stored in a {{<<urn:iso:std:iso:14812:3.1.10.3>>,data dictionary}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.10.3.yaml
+++ b/concepts/concept-3.1.10.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: data dictionary
   definition:
-  - content: collection of {{urn:iso:std:iso:14812:3.1.10.1,data concept,data concepts}}
-      that allows lookup by {{urn:iso:std:iso:14812:3.1.1.1,entity}} identifier
+  - content: collection of {{<<urn:iso:std:iso:14812:3.1.10.1>>,data concept,data concepts}}
+      that allows lookup by {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} identifier
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.10.4.yaml
+++ b/concepts/concept-3.1.10.4.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: data concept registry
   definition:
-  - content: electronic {{urn:iso:std:iso:14812:3.1.10.3,data dictionary}} that follows
-      precise documented rules for the registration and management of stored {{urn:iso:std:iso:14812:3.1.10.1,data
+  - content: electronic {{<<urn:iso:std:iso:14812:3.1.10.3>>,data dictionary}} that follows
+      precise documented rules for the registration and management of stored {{<<urn:iso:std:iso:14812:3.1.10.1>>,data
       concept,data concepts}}
   notes:
-  - content: The data concept registry contains {{urn:iso:std:iso:14812:3.1.10.2,meta-attribute,meta-attributes}}
+  - content: The data concept registry contains {{<<urn:iso:std:iso:14812:3.1.10.2>>,meta-attribute,meta-attributes}}
       about data concepts in terms of their names and representational forms as well
       as the semantics associated with the data concepts. A data concept registry
       may contain metadata that assists information interchange and re-use, both from

--- a/concepts/concept-3.1.11.1.yaml
+++ b/concepts/concept-3.1.11.1.yaml
@@ -12,7 +12,7 @@ eng:
   notes:
   - content: This definition states that a data element is “indivisible” in a given
       context. This means it is possible for a data element considered indivisible
-      in one context [e.g. {{urn:iso:std:iso:14812:3.4.1.1,location}}] to be divisible
+      in one context [e.g. {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}}] to be divisible
       in another context (e.g. latitude, longitude, and elevation).
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.11.4.yaml
+++ b/concepts/concept-3.1.11.4.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: data frame
   definition:
-  - content: specific grouping of {{urn:iso:std:iso:14812:3.1.11.1,data element,data
+  - content: specific grouping of {{<<urn:iso:std:iso:14812:3.1.11.1>>,data element,data
       elements}} that describes information of interest through a useful grouping
-      of more atomic properties about one or more {{urn:iso:std:iso:14812:3.1.11.2,class,classes}}
+      of more atomic properties about one or more {{<<urn:iso:std:iso:14812:3.1.11.2>>,class,classes}}
   notes:
   - content: The grouping can be a set, sequence or a choice.
   - content: A data frame can contain other data frames.

--- a/concepts/concept-3.1.11.5.yaml
+++ b/concepts/concept-3.1.11.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: message
   definition:
-  - content: grouping of {{urn:iso:std:iso:14812:3.1.11.1,data element,data elements}},
-      {{urn:iso:std:iso:14812:3.1.11.4,data frame,data frames}}, or data elements
+  - content: grouping of {{<<urn:iso:std:iso:14812:3.1.11.1>>,data element,data elements}},
+      {{<<urn:iso:std:iso:14812:3.1.11.4>>,data frame,data frames}}, or data elements
       and data frames that is used to convey information
   notes: []
   examples: []

--- a/concepts/concept-3.1.12.1.yaml
+++ b/concepts/concept-3.1.12.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: use case
   definition:
-  - content: description of the behavioural requirements of a {{urn:iso:std:iso:14812:3.1.2.1,system}}
-      and its {{urn:iso:std:iso:14812:3.1.6.4,interaction}} with a {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: description of the behavioural requirements of a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
+      and its {{<<urn:iso:std:iso:14812:3.1.6.4>>,interaction}} with a {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.12.2.yaml
+++ b/concepts/concept-3.1.12.2.yaml
@@ -11,7 +11,7 @@ eng:
     designation: use case scenario
   domain: use case
   definition:
-  - content: description of the sequence of events from the {{urn:iso:std:iso:14812:3.5.3.4,user,user's}}
+  - content: description of the sequence of events from the {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,user's}}
       perspective to perform a task in a specified context
   notes: []
   examples: []

--- a/concepts/concept-3.1.13.2.yaml
+++ b/concepts/concept-3.1.13.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: duration
   definition:
-  - content: time between two {{urn:iso:std:iso:14812:3.1.13.1,instant,instants}}
+  - content: time between two {{<<urn:iso:std:iso:14812:3.1.13.1>>,instant,instants}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.2.1.yaml
+++ b/concepts/concept-3.1.2.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: system
   definition:
-  - content: combination of interacting {{urn:iso:std:iso:14812:3.1.3.10,element,elements}}
+  - content: combination of interacting {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}}
       organized to achieve one or more stated purposes
   notes: []
   examples: []

--- a/concepts/concept-3.1.2.2.yaml
+++ b/concepts/concept-3.1.2.2.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: transport system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.2.1,system}} of infrastructure {{urn:iso:std:iso:14812:3.1.3.10,element,elements}}
-      and optionally {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}} that are jointly
-      designed to move {{urn:iso:std:iso:14812:3.1.1.3,material entity,material entities}}
+  - content: "{{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} of infrastructure {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}}
+      and optionally {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}} that are jointly
+      designed to move {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity,material entities}}
       from an origin to a destination"
   notes:
   - content: Transport systems can also include any supporting system, such as information

--- a/concepts/concept-3.1.2.3.yaml
+++ b/concepts/concept-3.1.2.3.yaml
@@ -10,11 +10,11 @@ eng:
     normative_status: admitted
     designation: transport system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.2.2,transport system}} designed to move
-      {{urn:iso:std:iso:14812:3.1.1.3,material entity,material entities}} across the
+  - content: "{{<<urn:iso:std:iso:14812:3.1.2.2>>,transport system}} designed to move
+      {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity,material entities}} across the
       surface or near-surface of the Earth"
   notes:
-  - content: A surface transport system can include tunnels, bridges and similar {{urn:iso:std:iso:14812:3.1.3.10,element,elements}}.
+  - content: A surface transport system can include tunnels, bridges and similar {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}}.
   - content: There is not complete agreement on the precise limitations of a "surface
       transport system" within the ITS community. Currently, the term is almost exclusively
       applied to ground-based travel of goods and people over significant distances.

--- a/concepts/concept-3.1.2.4.yaml
+++ b/concepts/concept-3.1.2.4.yaml
@@ -13,8 +13,8 @@ eng:
     normative_status: admitted
     designation: intelligent transportation system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.2.1,system}} comprised of information, communication,
-      sensor and control technologies and that is designed to benefit a {{urn:iso:std:iso:14812:3.1.2.3,surface
+  - content: "{{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} comprised of information, communication,
+      sensor and control technologies and that is designed to benefit a {{<<urn:iso:std:iso:14812:3.1.2.3>>,surface
       transport system}}"
   notes:
   - content: '"Intelligent transportation system" is the American English equivalent.'

--- a/concepts/concept-3.1.2.5.yaml
+++ b/concepts/concept-3.1.2.5.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: C-ITS
   definition:
-  - content: subset of {{urn:iso:std:iso:14812:3.1.2.4,intelligent transport system,ITS}}
-      where information is shared among {{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS
-      stations}} in a manner that enables its use by multiple {{urn:iso:std:iso:14812:3.5.3.1,ITS
+  - content: subset of {{<<urn:iso:std:iso:14812:3.1.2.4>>,intelligent transport system,ITS}}
+      where information is shared among {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS
+      stations}} in a manner that enables its use by multiple {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS
       service,ITS services}}
   notes: []
   examples: []

--- a/concepts/concept-3.1.3.1.yaml
+++ b/concepts/concept-3.1.3.1.yaml
@@ -11,9 +11,9 @@ eng:
     designation: system architecture
   domain: system
   definition:
-  - content: fundamental concepts or properties of a {{urn:iso:std:iso:14812:3.1.2.1,system}}
-      in its {{urn:iso:std:iso:14812:3.1.3.11,environment}} embodied in its {{urn:iso:std:iso:14812:3.1.3.10,element,elements}},
-      {{urn:iso:std:iso:14812:3.1.6.8,relationship,relationships}} and in the principles
+  - content: fundamental concepts or properties of a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
+      in its {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment}} embodied in its {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}},
+      {{<<urn:iso:std:iso:14812:3.1.6.8>>,relationship,relationships}} and in the principles
       of its design and evolution
   notes: []
   examples: []

--- a/concepts/concept-3.1.3.10.yaml
+++ b/concepts/concept-3.1.3.10.yaml
@@ -11,8 +11,8 @@ eng:
     designation: architecture element
   domain: architecture
   definition:
-  - content: component member of an {{urn:iso:std:iso:14812:3.1.3.9,architecture model}}
-      included in an {{urn:iso:std:iso:14812:3.1.3.7,architecture view}}
+  - content: component member of an {{<<urn:iso:std:iso:14812:3.1.3.9>>,architecture model}}
+      included in an {{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.11.yaml
+++ b/concepts/concept-3.1.3.11.yaml
@@ -12,7 +12,7 @@ eng:
   domain: system
   definition:
   - content: context determining the setting and circumstances of all influences upon
-      a {{urn:iso:std:iso:14812:3.1.2.1,system}}
+      a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
   notes:
   - content: The environment of a system includes developmental, technological, business,
       operational, organizational, political, economic, legal, regulatory, ecological

--- a/concepts/concept-3.1.3.2.yaml
+++ b/concepts/concept-3.1.3.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: architecture description
   definition:
-  - content: work product used to express an {{urn:iso:std:iso:14812:3.1.3.1,architecture}}
+  - content: work product used to express an {{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.3.yaml
+++ b/concepts/concept-3.1.3.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: architecture framework
   definition:
-  - content: conventions, principles and practices for the description of {{urn:iso:std:iso:14812:3.1.3.1,architecture,architectures}}
-      established within a specific domain of application and/or community of {{urn:iso:std:iso:14812:3.1.3.4,stakeholder,stakeholders}}
+  - content: conventions, principles and practices for the description of {{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture,architectures}}
+      established within a specific domain of application and/or community of {{<<urn:iso:std:iso:14812:3.1.3.4>>,stakeholder,stakeholders}}
   notes: []
   examples:
   - content: Generalised Enterprise Reference Architecture and Methodologies (GERAM)

--- a/concepts/concept-3.1.3.4.yaml
+++ b/concepts/concept-3.1.3.4.yaml
@@ -11,8 +11,8 @@ eng:
     designation: system stakeholder
   domain: system
   definition:
-  - content: individual, team, organization, or {{urn:iso:std:iso:14812:3.1.12.2,scenario,classes}}
-      thereof, having an interest in a {{urn:iso:std:iso:14812:3.1.2.1,system}}
+  - content: individual, team, organization, or {{<<urn:iso:std:iso:14812:3.1.12.2>>,scenario,classes}}
+      thereof, having an interest in a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.5.yaml
+++ b/concepts/concept-3.1.3.5.yaml
@@ -11,10 +11,10 @@ eng:
     designation: system concern
   domain: system
   definition:
-  - content: interest in a {{urn:iso:std:iso:14812:3.1.2.1,system}} relevant to one
-      or more of its {{urn:iso:std:iso:14812:3.1.3.4,stakeholder,stakeholders}}
+  - content: interest in a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} relevant to one
+      or more of its {{<<urn:iso:std:iso:14812:3.1.3.4>>,stakeholder,stakeholders}}
   notes:
-  - content: A concern pertains to any influence on a system in its {{urn:iso:std:iso:14812:3.1.3.11,environment}},
+  - content: A concern pertains to any influence on a system in its {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment}},
       including developmental, technological, business, operational, organizational,
       political, economic, legal, regulatory, ecological and social influences.
   examples: []

--- a/concepts/concept-3.1.3.6.yaml
+++ b/concepts/concept-3.1.3.6.yaml
@@ -8,8 +8,8 @@ eng:
     designation: architecture viewpoint
   definition:
   - content: work product establishing the conventions for the construction, interpretation
-      and use of {{urn:iso:std:iso:14812:3.1.3.7,architecture view,architecture views}}
-      to frame specific system {{urn:iso:std:iso:14812:3.1.3.5,concern,concerns}}
+      and use of {{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view,architecture views}}
+      to frame specific system {{<<urn:iso:std:iso:14812:3.1.3.5>>,concern,concerns}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.7.yaml
+++ b/concepts/concept-3.1.3.7.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: architecture view
   definition:
-  - content: work product expressing the {{urn:iso:std:iso:14812:3.1.3.1,architecture}}
-      of a {{urn:iso:std:iso:14812:3.1.2.1,system}} from the perspective of specific
-      system {{urn:iso:std:iso:14812:3.1.3.5,concern,concerns}}
+  - content: work product expressing the {{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}}
+      of a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} from the perspective of specific
+      system {{<<urn:iso:std:iso:14812:3.1.3.5>>,concern,concerns}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.8.yaml
+++ b/concepts/concept-3.1.3.8.yaml
@@ -9,8 +9,8 @@ eng:
   definition:
   - content: conventions for a type of modelling
   notes:
-  - content: Examples of model kinds include {{urn:iso:std:iso:14812:3.1.7.1,data
-      flow}} diagrams, {{urn:iso:std:iso:14812:3.1.11.2,class}} diagrams, Petri nets,
+  - content: Examples of model kinds include {{<<urn:iso:std:iso:14812:3.1.7.1>>,data
+      flow}} diagrams, {{<<urn:iso:std:iso:14812:3.1.11.2>>,class}} diagrams, Petri nets,
       balance sheets, organization charts and state transition models.
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.3.9.yaml
+++ b/concepts/concept-3.1.3.9.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: architecture model
   definition:
-  - content: work product representing one or more {{urn:iso:std:iso:14812:3.1.3.7,architecture
-      view,architecture views}} and expressed in a format governed by a {{urn:iso:std:iso:14812:3.1.3.8,model
+  - content: work product representing one or more {{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture
+      view,architecture views}} and expressed in a format governed by a {{<<urn:iso:std:iso:14812:3.1.3.8>>,model
       kind}}
   notes: []
   examples: []

--- a/concepts/concept-3.1.4.1.yaml
+++ b/concepts/concept-3.1.4.1.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: communications view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.7,architecture view}} from the {{urn:iso:std:iso:14812:3.1.4.2,communications
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view}} from the {{<<urn:iso:std:iso:14812:3.1.4.2>>,communications
       viewpoint}}"
   notes:
   - content: Within ITS, the preferred model for describing the communications view
-      is based on the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture}}.
+      is based on the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference architecture}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.4.2.yaml
+++ b/concepts/concept-3.1.4.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: communications viewpoint
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.6,architecture viewpoint}} used to frame
-      {{urn:iso:std:iso:14812:3.1.3.5,concern,concerns}} related to all layers of
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.6>>,architecture viewpoint}} used to frame
+      {{<<urn:iso:std:iso:14812:3.1.3.5>>,concern,concerns}} related to all layers of
       the Open Systems Interconnection (OSI) stack and related management and security
       issues"
   notes: []

--- a/concepts/concept-3.1.4.3.yaml
+++ b/concepts/concept-3.1.4.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.7,architecture view}} from the {{urn:iso:std:iso:14812:3.1.4.4,enterprise
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view}} from the {{<<urn:iso:std:iso:14812:3.1.4.4>>,enterprise
       viewpoint}}"
   notes: []
   examples: []

--- a/concepts/concept-3.1.4.4.yaml
+++ b/concepts/concept-3.1.4.4.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: enterprise viewpoint
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.6,architecture viewpoint}} used to frame
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.6>>,architecture viewpoint}} used to frame
       the policies, funding incentives, working arrangements and jurisdictional structure
-      that support the technical layers of the{{urn:iso:std:iso:14812:3.1.3.1,architecture}}"
+      that support the technical layers of the{{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.4.5.yaml
+++ b/concepts/concept-3.1.4.5.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: functional view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.7,architecture view}} from the {{urn:iso:std:iso:14812:3.1.4.6,functional
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view}} from the {{<<urn:iso:std:iso:14812:3.1.4.6>>,functional
       viewpoint}}"
   notes: []
   examples: []

--- a/concepts/concept-3.1.4.6.yaml
+++ b/concepts/concept-3.1.4.6.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: functional viewpoint
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.6,architecture viewpoint}} used to frame
-      {{urn:iso:std:iso:14812:3.1.3.5,concern,concerns}} related to the definition
-      of {{urn:iso:std:iso:14812:3.1.7.2,process,processes}} that perform surface
-      transport functions and {{urn:iso:std:iso:14812:3.1.7.1,data flow,data flows}}
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.6>>,architecture viewpoint}} used to frame
+      {{<<urn:iso:std:iso:14812:3.1.3.5>>,concern,concerns}} related to the definition
+      of {{<<urn:iso:std:iso:14812:3.1.7.2>>,process,processes}} that perform surface
+      transport functions and {{<<urn:iso:std:iso:14812:3.1.7.1>>,data flow,data flows}}
       shared between these processes"
   notes: []
   examples: []

--- a/concepts/concept-3.1.4.7.yaml
+++ b/concepts/concept-3.1.4.7.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: physical view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.7,architecture view}} from the {{urn:iso:std:iso:14812:3.1.4.8,physical
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.7>>,architecture view}} from the {{<<urn:iso:std:iso:14812:3.1.4.8>>,physical
       viewpoint}}"
   notes:
   - content: The term "deployment view" is sometimes used within the broader ICT community,
       but the term "physical view" is preferred to prevent confusion between the physical
-      view of a reference architecture and any part of a {{urn:iso:std:iso:14812:3.1.9.3,deployment
+      view of a reference architecture and any part of a {{<<urn:iso:std:iso:14812:3.1.9.3>>,deployment
       architecture}}.
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.4.8.yaml
+++ b/concepts/concept-3.1.4.8.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: physical viewpoint
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.6,architecture viewpoint}} used to frame
-      {{urn:iso:std:iso:14812:3.1.3.5,concern,concerns}} related to the assignment
-      of functionality to {{urn:iso:std:iso:14812:3.1.8.1,physical object,physical
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.6>>,architecture viewpoint}} used to frame
+      {{<<urn:iso:std:iso:14812:3.1.3.5>>,concern,concerns}} related to the assignment
+      of functionality to {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical object,physical
       objects}} and the interfaces among these physical objects"
   notes: []
   examples: []

--- a/concepts/concept-3.1.5.1.yaml
+++ b/concepts/concept-3.1.5.1.yaml
@@ -14,7 +14,7 @@ eng:
     designation: information layer
   domain: ITS-S
   definition:
-  - content: part of the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture,ITS
+  - content: part of the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference architecture,ITS
       station reference architecture}} that is responsible for providing ITS-related
       functionality
   notes:
@@ -22,7 +22,7 @@ eng:
       (NTCIP) standards identify an "information layer" on top of the traditional
       OSI stack. However, the purpose of this layer includes both information configuration
       and functionality. The ITS-S reference architecture separates these two roles
-      between the {{urn:iso:std:iso:14812:3.1.5.6,management entity}} and the application
+      between the {{<<urn:iso:std:iso:14812:3.1.5.6>>,management entity}} and the application
       entity.
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.5.3.yaml
+++ b/concepts/concept-3.1.5.3.yaml
@@ -14,7 +14,7 @@ eng:
     designation: subnet layer
   domain: ITS-S
   definition:
-  - content: protocol layer in the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference
+  - content: protocol layer in the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference
       architecture,ITS station reference architecture}} containing the OSI physical
       and data link layer protocols for ITS communications
   notes:

--- a/concepts/concept-3.1.5.4.yaml
+++ b/concepts/concept-3.1.5.4.yaml
@@ -14,7 +14,7 @@ eng:
     designation: networking and transport layer
   domain: ITS-S
   definition:
-  - content: protocol layer in the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference
+  - content: protocol layer in the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference
       architecture,ITS station reference architecture}} containing the OSI network
       and transport layer protocols
   notes:

--- a/concepts/concept-3.1.5.5.yaml
+++ b/concepts/concept-3.1.5.5.yaml
@@ -14,13 +14,13 @@ eng:
     designation: application layer
   domain: ITS-S
   definition:
-  - content: protocol layer in the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference
+  - content: protocol layer in the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference
       architecture,ITS station reference architecture}} containing the OSI session,
       presentation and application layer protocols
   notes:
   - content: Within the US, the NTCIP standards call the facilities layer the "application
       layer". However, as this term is easily confused with both the OSI application
-      layer and the {{urn:iso:std:iso:14812:3.1.5.1,application entity}}, the term
+      layer and the {{<<urn:iso:std:iso:14812:3.1.5.1>>,application entity}}, the term
       should be avoided and qualified when used (e.g. OSI application layer).
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.5.6.yaml
+++ b/concepts/concept-3.1.5.6.yaml
@@ -11,9 +11,9 @@ eng:
     designation: ITS-S management entity
   domain: ITS-S
   definition:
-  - content: part of the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture,ITS
+  - content: part of the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference architecture,ITS
       station reference architecture}} that is responsible for management of communications
-      and configuration information for the local {{urn:iso:std:iso:14812:3.1.8.1,physical
+      and configuration information for the local {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical
       object}} and possibly remote physical objects
   notes: []
   examples: []

--- a/concepts/concept-3.1.5.7.yaml
+++ b/concepts/concept-3.1.5.7.yaml
@@ -11,9 +11,9 @@ eng:
     designation: ITS-S security entity
   domain: ITS-S
   definition:
-  - content: part of the {{urn:iso:std:iso:14812:3.1.9.4,ITS-S reference architecture,ITS
+  - content: part of the {{<<urn:iso:std:iso:14812:3.1.9.4>>,ITS-S reference architecture,ITS
       station reference architecture}} that is responsible for providing privacy,
-      communication security and {{urn:iso:std:iso:14812:3.1.2.1,system}} security
+      communication security and {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} security
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.6.1.yaml
+++ b/concepts/concept-3.1.6.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: enterprise object
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} within an {{urn:iso:std:iso:14812:3.1.4.3,enterprise
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} within an {{<<urn:iso:std:iso:14812:3.1.4.3>>,enterprise
       view}} that represents an organization or individual"
   notes: []
   examples: []

--- a/concepts/concept-3.1.6.10.yaml
+++ b/concepts/concept-3.1.6.10.yaml
@@ -11,11 +11,11 @@ eng:
     designation: enterprise view extend
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.6.8,relationship}} where one {{urn:iso:std:iso:14812:3.1.6.2,resource}}
+  - content: "{{<<urn:iso:std:iso:14812:3.1.6.8>>,relationship}} where one {{<<urn:iso:std:iso:14812:3.1.6.2>>,resource}}
       supplements another resource"
   notes: []
   examples:
-  - content: A {{urn:iso:std:iso:14812:3.1.8.7,module}} can extend the functionality
+  - content: A {{<<urn:iso:std:iso:14812:3.1.8.7>>,module}} can extend the functionality
       of another module.
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.6.2.yaml
+++ b/concepts/concept-3.1.6.2.yaml
@@ -11,8 +11,8 @@ eng:
     designation: enterprise view resource
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} that represents an {{urn:iso:std:iso:14812:3.1.1.1,entity}}
-      that is managed, operated, referenced and/or used to develop and provide {{urn:iso:std:iso:14812:3.1.2.4,intelligent
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} that represents an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}
+      that is managed, operated, referenced and/or used to develop and provide {{<<urn:iso:std:iso:14812:3.1.2.4>>,intelligent
       transport system,ITS}}"
   notes: []
   examples: []

--- a/concepts/concept-3.1.6.4.yaml
+++ b/concepts/concept-3.1.6.4.yaml
@@ -11,8 +11,8 @@ eng:
     designation: enterprise view interaction
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} that represents coordination
-      between two {{urn:iso:std:iso:14812:3.1.6.1,enterprise object,enterprise objects}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} that represents coordination
+      between two {{<<urn:iso:std:iso:14812:3.1.6.1>>,enterprise object,enterprise objects}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.6.5.yaml
+++ b/concepts/concept-3.1.6.5.yaml
@@ -11,13 +11,13 @@ eng:
     designation: enterprise view formal coordination
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.6.4,interaction}} between two {{urn:iso:std:iso:14812:3.1.6.1,enterprise
+  - content: "{{<<urn:iso:std:iso:14812:3.1.6.4>>,interaction}} between two {{<<urn:iso:std:iso:14812:3.1.6.1>>,enterprise
       object,enterprise objects}} governed by a documented agreement"
   notes: []
   examples:
   - content: A road operator can enter into formal agreement(s) with the owner of
-      a {{urn:iso:std:iso:14812:3.3.5.1,road}} and the owner(s) of the associated
-      {{urn:iso:std:iso:14812:3.3.1.10,roadside}} equipment.
+      a {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} and the owner(s) of the associated
+      {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}} equipment.
   language_code: eng
   entry_status: valid
   sources:

--- a/concepts/concept-3.1.6.6.yaml
+++ b/concepts/concept-3.1.6.6.yaml
@@ -11,7 +11,7 @@ eng:
     designation: enterprise view informal coordination
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.6.4,interaction}} between two {{urn:iso:std:iso:14812:3.1.6.1,enterprise
+  - content: "{{<<urn:iso:std:iso:14812:3.1.6.4>>,interaction}} between two {{<<urn:iso:std:iso:14812:3.1.6.1>>,enterprise
       object,enterprise objects}} governed by an understanding that is not documented
       in a formal agreement between the two parties"
   notes: []

--- a/concepts/concept-3.1.6.7.yaml
+++ b/concepts/concept-3.1.6.7.yaml
@@ -11,9 +11,9 @@ eng:
     designation: enterprise view role
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} that represents the specified
-      responsibilities between an {{urn:iso:std:iso:14812:3.1.6.1,enterprise object}}
-      and another {{urn:iso:std:iso:14812:3.1.4.3,enterprise view}} element"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} that represents the specified
+      responsibilities between an {{<<urn:iso:std:iso:14812:3.1.6.1>>,enterprise object}}
+      and another {{<<urn:iso:std:iso:14812:3.1.4.3>>,enterprise view}} element"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.6.8.yaml
+++ b/concepts/concept-3.1.6.8.yaml
@@ -11,8 +11,8 @@ eng:
     designation: enterprise view relationship
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} that represents an association
-      between two {{urn:iso:std:iso:14812:3.1.6.2,resource,resources}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} that represents an association
+      between two {{<<urn:iso:std:iso:14812:3.1.6.2>>,resource,resources}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.6.9.yaml
+++ b/concepts/concept-3.1.6.9.yaml
@@ -11,11 +11,11 @@ eng:
     designation: enterprise view include
   domain: enterprise view
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.6.8,relationship}} where one {{urn:iso:std:iso:14812:3.1.6.2,resource}}
+  - content: "{{<<urn:iso:std:iso:14812:3.1.6.8>>,relationship}} where one {{<<urn:iso:std:iso:14812:3.1.6.2>>,resource}}
       contains another resource"
   notes: []
   examples:
-  - content: Every ITS component includes one or more {{urn:iso:std:iso:14812:3.1.8.7,module,modules}}.
+  - content: Every ITS component includes one or more {{<<urn:iso:std:iso:14812:3.1.8.7>>,module,modules}}.
   language_code: eng
   entry_status: valid
   sources:

--- a/concepts/concept-3.1.7.1.yaml
+++ b/concepts/concept-3.1.7.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: data flow
   definition:
-  - content: representation of data flowing between two {{urn:iso:std:iso:14812:3.1.7.2,process,processes}}
-      or between a process and a {{urn:iso:std:iso:14812:3.1.8.3,terminator}}
+  - content: representation of data flowing between two {{<<urn:iso:std:iso:14812:3.1.7.2>>,process,processes}}
+      or between a process and a {{<<urn:iso:std:iso:14812:3.1.8.3>>,terminator}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.7.2.yaml
+++ b/concepts/concept-3.1.7.2.yaml
@@ -11,8 +11,8 @@ eng:
     designation: functional view process
   domain: functional view
   definition:
-  - content: series of one or more {{urn:iso:std:iso:14812:3.1.7.3,function,functions}}
-      in support of an {{urn:iso:std:iso:14812:3.5.3.1,ITS service}}
+  - content: series of one or more {{<<urn:iso:std:iso:14812:3.1.7.3>>,function,functions}}
+      in support of an {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.7.3.yaml
+++ b/concepts/concept-3.1.7.3.yaml
@@ -15,7 +15,7 @@ eng:
       a goal
   notes:
   - content: A function transforms inputs into outputs that may include the creation,
-      modification, monitoring or destruction of {{urn:iso:std:iso:14812:3.1.3.10,element,elements}}.
+      modification, monitoring or destruction of {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.7.4.yaml
+++ b/concepts/concept-3.1.7.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: process specification
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.6.3,document}} that defines a lowest-level
-      {{urn:iso:std:iso:14812:3.1.7.2,process}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.6.3>>,document}} that defines a lowest-level
+      {{<<urn:iso:std:iso:14812:3.1.7.2>>,process}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.8.1.yaml
+++ b/concepts/concept-3.1.8.1.yaml
@@ -11,16 +11,16 @@ eng:
     designation: ITS physical object
   domain: physical view
   definition:
-  - content: abstraction of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}} that
-      interacts with other abstract material entities in the provision of {{urn:iso:std:iso:14812:3.5.3.1,ITS
+  - content: abstraction of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that
+      interacts with other abstract material entities in the provision of {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS
       service,ITS services}}
   notes:
-  - content: Physical objects are represented as {{urn:iso:std:iso:14812:3.1.3.10,element,elements}}
-      within the {{urn:iso:std:iso:14812:3.1.4.7,physical view}} and perform a role.
-      Physical objects can be implemented as cloud-based {{urn:iso:std:iso:14812:3.1.2.1,system,systems}}.
-  - content: 'Within many {{urn:iso:std:iso:14812:3.1.9.5,ITS reference architecture,ITS
+  - content: Physical objects are represented as {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,elements}}
+      within the {{<<urn:iso:std:iso:14812:3.1.4.7>>,physical view}} and perform a role.
+      Physical objects can be implemented as cloud-based {{<<urn:iso:std:iso:14812:3.1.2.1>>,system,systems}}.
+  - content: 'Within many {{<<urn:iso:std:iso:14812:3.1.9.5>>,ITS reference architecture,ITS
       reference architectures}}, physical objects are placed into one of five categories:
-      centre, support, field, vehicle or {{urn:iso:std:iso:14812:3.6.1.1,traveller}}.'
+      centre, support, field, vehicle or {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller}}.'
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.8.2.yaml
+++ b/concepts/concept-3.1.8.2.yaml
@@ -7,13 +7,13 @@ eng:
     normative_status: preferred
     designation: ITS component
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.1,physical object}} that has been assigned
-      one or more {{urn:iso:std:iso:14812:3.1.8.6,functional object,functional objects}}
-      in the provision of one or more {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.1>>,physical object}} that has been assigned
+      one or more {{<<urn:iso:std:iso:14812:3.1.8.6>>,functional object,functional objects}}
+      in the provision of one or more {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS
       services}}"
   notes:
   - content: Physical objects are ITS components if they are an integral part of the
-      {{urn:iso:std:iso:14812:3.1.2.1,system}}; otherwise they are {{urn:iso:std:iso:14812:3.1.8.3,terminator,terminators}}.
+      {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}; otherwise they are {{<<urn:iso:std:iso:14812:3.1.8.3>>,terminator,terminators}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.1.8.3.yaml
+++ b/concepts/concept-3.1.8.3.yaml
@@ -10,12 +10,12 @@ eng:
     normative_status: preferred
     designation: ITS terminator
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that is external to the {{urn:iso:std:iso:14812:3.5.3.1,ITS
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that is external to the {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS
       service}} implementation but with which the implementation communicates either
       to obtain inputs or to which it can send outputs"
   notes:
-  - content: A terminator can exist within {{urn:iso:std:iso:14812:3.1.4.5,functional
-      view,functional}} and {{urn:iso:std:iso:14812:3.1.4.7,physical view,physical
+  - content: A terminator can exist within {{<<urn:iso:std:iso:14812:3.1.4.5>>,functional
+      view,functional}} and {{<<urn:iso:std:iso:14812:3.1.4.7>>,physical view,physical
       views}}.
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.8.4.yaml
+++ b/concepts/concept-3.1.8.4.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: information flow
   definition:
-  - content: information that is exchanged between {{urn:iso:std:iso:14812:3.1.8.1,physical
+  - content: information that is exchanged between {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical
       object,physical objects}}
   notes: []
   examples: []

--- a/concepts/concept-3.1.8.5.yaml
+++ b/concepts/concept-3.1.8.5.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: admitted
     designation: information flow triple
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.4,information flow}} from a {{urn:iso:std:iso:14812:3.1.8.1,physical
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.4>>,information flow}} from a {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical
       object}} acting as an information provider and sent to another physical object
       acting as an information consumer"
   notes:

--- a/concepts/concept-3.1.8.6.yaml
+++ b/concepts/concept-3.1.8.6.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: ITS functional object
   definition:
-  - content: set of related {{urn:iso:std:iso:14812:3.1.7.2,process,processes}} that
-      are performed by a {{urn:iso:std:iso:14812:3.1.8.1,physical object}} to fulfil
-      aspects of an {{urn:iso:std:iso:14812:3.5.3.1,ITS service}}
+  - content: set of related {{<<urn:iso:std:iso:14812:3.1.7.2>>,process,processes}} that
+      are performed by a {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical object}} to fulfil
+      aspects of an {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service}}
   notes:
   - content: The term "module" is used by the European FRAME architecture while the
       Architecture Reference for Cooperative and Intelligent Transportation (ARC-IT)

--- a/concepts/concept-3.1.8.7.yaml
+++ b/concepts/concept-3.1.8.7.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS module
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.6,functional object}} that can be replaced
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.6>>,functional object}} that can be replaced
       and has defined interfaces"
   notes: []
   examples: []

--- a/concepts/concept-3.1.9.1.yaml
+++ b/concepts/concept-3.1.9.1.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: reference architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.1,architecture}} that provides a template
-      solution for {{urn:iso:std:iso:14812:3.1.9.2,planning architecture,planning}}
-      and {{urn:iso:std:iso:14812:3.1.9.3,deployment architecture,deployment architectures}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}} that provides a template
+      solution for {{<<urn:iso:std:iso:14812:3.1.9.2>>,planning architecture,planning}}
+      and {{<<urn:iso:std:iso:14812:3.1.9.3>>,deployment architecture,deployment architectures}}"
   notes:
   - content: Interface standards are based on a reference architecture, which should
       be explicitly described.

--- a/concepts/concept-3.1.9.2.yaml
+++ b/concepts/concept-3.1.9.2.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: admitted
     designation: regional architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.1,architecture}} that provides a long-term
-      vision of {{urn:iso:std:iso:14812:3.1.3.10,element,system elements}} that may
-      be deployed and managed by different projects and/or {{urn:iso:std:iso:14812:3.1.1.1,entity,entities}}
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}} that provides a long-term
+      vision of {{<<urn:iso:std:iso:14812:3.1.3.10>>,element,system elements}} that may
+      be deployed and managed by different projects and/or {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity,entities}}
       within a geographic area"
   notes:
   - content: Some countries use the term "regional architecture", but in International

--- a/concepts/concept-3.1.9.3.yaml
+++ b/concepts/concept-3.1.9.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: deployment architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.1,architecture}} that provides a vision
-      of a specific deployment of a {{urn:iso:std:iso:14812:3.1.2.1,system}} within
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.1>>,architecture}} that provides a vision
+      of a specific deployment of a {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} within
       a geographic area"
   notes: []
   examples: []

--- a/concepts/concept-3.1.9.4.yaml
+++ b/concepts/concept-3.1.9.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S reference architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.9.1,reference architecture}} for handling
-      communications within a {{urn:iso:std:iso:14812:3.1.8.1,physical object}} as
+  - content: "{{<<urn:iso:std:iso:14812:3.1.9.1>>,reference architecture}} for handling
+      communications within a {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical object}} as
       defined in <<ref_16,ISO 21217>>"
   notes:
   - content: The ITS-S reference architecture provides a model for describing communication.

--- a/concepts/concept-3.1.9.5.yaml
+++ b/concepts/concept-3.1.9.5.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: ITS reference architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.9.1,reference architecture}} for one or
-      more {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.9.1>>,reference architecture}} for one or
+      more {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}}"
   notes:
-  - content: An ITS architecture can be a reference, planning or {{urn:iso:std:iso:14812:3.1.9.3,deployment
+  - content: An ITS architecture can be a reference, planning or {{<<urn:iso:std:iso:14812:3.1.9.3>>,deployment
       architecture}}.
   - content: The Harmonised Architecture Reference for Technical Standards (HARTS;
       http://htg7.org[see] Reference <<ref_26>>) is an example of an ITS reference

--- a/concepts/concept-3.1.9.6.yaml
+++ b/concepts/concept-3.1.9.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS planning architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.9.2,planning architecture}} for one or more
-      {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.9.2>>,planning architecture}} for one or more
+      {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.1.9.7.yaml
+++ b/concepts/concept-3.1.9.7.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS deployment architecture
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.9.3,deployment architecture}} for one or
-      more {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.9.3>>,deployment architecture}} for one or
+      more {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.1.1.yaml
+++ b/concepts/concept-3.2.1.1.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: ITS central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.2,ITS component}} that provides application,
-      management, and/or administrative functions from a centralized{{urn:iso:std:iso:14812:3.4.1.1,location}},
-      i.e. not at the {{urn:iso:std:iso:14812:3.3.1.10,roadside}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component}} that provides application,
+      management, and/or administrative functions from a centralized{{<<urn:iso:std:iso:14812:3.4.1.1>>,location}},
+      i.e. not at the {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.1.2.yaml
+++ b/concepts/concept-3.2.1.2.yaml
@@ -13,11 +13,11 @@ eng:
     normative_status: preferred
     designation: roadside system
   definition:
-  - content: infrastructure-based {{urn:iso:std:iso:14812:3.1.8.2,ITS component}}
+  - content: infrastructure-based {{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component}}
       located outside of a data centre that is designed to provide local processing
       or routing services while stationary
   notes:
-  - content: Typically, field systems are located along the {{urn:iso:std:iso:14812:3.3.1.10,roadside}}.
+  - content: Typically, field systems are located along the {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}}.
   - content: Typically, the operation of a field system is governed by management
       functions running in a centre system.
   - content: Field systems can be permanently installed or transportable.

--- a/concepts/concept-3.2.1.3.yaml
+++ b/concepts/concept-3.2.1.3.yaml
@@ -13,8 +13,8 @@ eng:
     normative_status: preferred
     designation: traveller system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.2,ITS component}}, other than a {{urn:iso:std:iso:14812:3.2.1.5,vehicle
-      system}}, that is used by a {{urn:iso:std:iso:14812:3.1.1.6,person}} in relation
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component}}, other than a {{<<urn:iso:std:iso:14812:3.2.1.5>>,vehicle
+      system}}, that is used by a {{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} in relation
       to a past, current or upcoming journey"
   notes: []
   examples: []

--- a/concepts/concept-3.2.1.4.yaml
+++ b/concepts/concept-3.2.1.4.yaml
@@ -10,12 +10,12 @@ eng:
     normative_status: preferred
     designation: ITS support system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.2,ITS component}} that provides services
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component}} that provides services
       in support of one or more other ITS components"
   notes: []
   examples:
-  - content: Data distribution {{urn:iso:std:iso:14812:3.1.2.1,system}}, network time
-      source, {{urn:iso:std:iso:14812:3.1.2.5,cooperative ITS}} credentials management
+  - content: Data distribution {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}, network time
+      source, {{<<urn:iso:std:iso:14812:3.1.2.5>>,cooperative ITS}} credentials management
       system.
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.2.1.5.yaml
+++ b/concepts/concept-3.2.1.5.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS vehicle system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.8.2,ITS component}} that is installed as
-      a component of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component}} that is installed as
+      a component of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.2.1.yaml
+++ b/concepts/concept-3.2.2.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: emergency management central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
-      allows an {{urn:iso:std:iso:14812:3.1.1.1,entity}} to manage and respond to
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
+      allows an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} to manage and respond to
       crashes, events, disasters, evacuation orders and other incidents"
   notes: []
   examples: []

--- a/concepts/concept-3.2.2.2.yaml
+++ b/concepts/concept-3.2.2.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: fleet and freight management central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
       allows a fleet or freight operator to manage and control its personnel, equipment
       and/or freight"
   notes: []

--- a/concepts/concept-3.2.2.3.yaml
+++ b/concepts/concept-3.2.2.3.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: maintenance and construction central management system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
-      allows an {{urn:iso:std:iso:14812:3.1.1.1,entity}} to monitor and manage the
-      construction and maintenance of {{urn:iso:std:iso:14812:3.3.5.1,road}} infrastructure"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
+      allows an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} to monitor and manage the
+      construction and maintenance of {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} infrastructure"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.2.4.yaml
+++ b/concepts/concept-3.2.2.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: payment administration central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
-      allows an {{urn:iso:std:iso:14812:3.1.1.1,entity}} to manage financial transactions
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
+      allows an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} to manage financial transactions
       related to transportation, especially the electronic transfer of funds"
   notes: []
   examples: []

--- a/concepts/concept-3.2.2.5.yaml
+++ b/concepts/concept-3.2.2.5.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: public transport central management system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
-      allows an {{urn:iso:std:iso:14812:3.1.1.1,entity}} to manage the activities
-      of a {{urn:iso:std:iso:14812:3.5.6.1,public transport}} agency"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
+      allows an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} to manage the activities
+      of a {{<<urn:iso:std:iso:14812:3.5.6.1>>,public transport}} agency"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.2.6.yaml
+++ b/concepts/concept-3.2.2.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: traffic management central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
-      monitors and controls traffic and the {{urn:iso:std:iso:14812:3.3.5.2,road network}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
+      monitors and controls traffic and the {{<<urn:iso:std:iso:14812:3.3.5.2>>,road network}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.2.7.yaml
+++ b/concepts/concept-3.2.2.7.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: traffic regulation central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
       officially records traffic regulations in electronic form so that they can be
       distributed to other systems"
   notes: []

--- a/concepts/concept-3.2.2.8.yaml
+++ b/concepts/concept-3.2.2.8.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: transport information central system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.1,central system,centre system}} that
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.1>>,central system,centre system}} that
       provides information of interest to the travelling public"
   notes: []
   examples: []

--- a/concepts/concept-3.2.3.1.yaml
+++ b/concepts/concept-3.2.3.1.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS field support equipment
   definition:
-  - content: portable {{urn:iso:std:iso:14812:3.2.1.2,field system}} used by field
+  - content: portable {{<<urn:iso:std:iso:14812:3.2.1.2>>,field system}} used by field
       personnel to locally troubleshoot, initialize, reprogram and test infrastructure
       equipment
   notes: []

--- a/concepts/concept-3.2.3.2.yaml
+++ b/concepts/concept-3.2.3.2.yaml
@@ -10,15 +10,15 @@ eng:
     normative_status: preferred
     designation: ITS roadway equipment
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.2,field system}} that performs localized
-      {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.2>>,field system}} that performs localized
+      {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}}"
   notes:
   - content: ITS services that can be performed by ITS roadside equipment include
       surveillance, traffic control, information provision, payment transaction services,
       and/or enforcement
   - content: '"ITS roadway equipment" is used within the current version of the Architecture
       Reference for Cooperative and Intelligent Transportation (ARC-IT; see Reference
-      <<ref_25>>). The term {{urn:iso:std:iso:14812:3.3.1.3,roadway}} has been revised
+      <<ref_25>>). The term {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} has been revised
       to reflect that the equipment is typically along the roadway rather than a part
       of the roadway.'
   examples:

--- a/concepts/concept-3.2.3.3.yaml
+++ b/concepts/concept-3.2.3.3.yaml
@@ -16,10 +16,10 @@ eng:
     normative_status: admitted
     designation: connected vehicle roadside equipment
   definition:
-  - content: ITS {{urn:iso:std:iso:14812:3.2.3.2,ITS roadside equipment,roadside equipment}}
-      that perform {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}} by exchanging
-      electronic {{urn:iso:std:iso:14812:3.1.11.5,message}} with nearby {{urn:iso:std:iso:14812:3.2.1.5,vehicle
-      system,vehicle systems}} and/or {{urn:iso:std:iso:14812:3.2.1.3,personal system,personal
+  - content: ITS {{<<urn:iso:std:iso:14812:3.2.3.2>>,ITS roadside equipment,roadside equipment}}
+      that perform {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}} by exchanging
+      electronic {{<<urn:iso:std:iso:14812:3.1.11.5>>,message}} with nearby {{<<urn:iso:std:iso:14812:3.2.1.5>>,vehicle
+      system,vehicle systems}} and/or {{<<urn:iso:std:iso:14812:3.2.1.3>>,personal system,personal
       systems}} via short-range wireless technologies
   notes:
   - content: Connected roadside equipment typically provides ITS-related functionality

--- a/concepts/concept-3.2.3.4.yaml
+++ b/concepts/concept-3.2.3.4.yaml
@@ -13,9 +13,9 @@ eng:
     normative_status: preferred
     designation: RSU
   definition:
-  - content: part of {{urn:iso:std:iso:14812:3.2.3.3,connected roadside equipment}}
-      that provides wireless connectivity to {{urn:iso:std:iso:14812:3.2.1.5,vehicle
-      system,vehicle systems}} and/or {{urn:iso:std:iso:14812:3.2.1.3,personal system,personal
+  - content: part of {{<<urn:iso:std:iso:14812:3.2.3.3>>,connected roadside equipment}}
+      that provides wireless connectivity to {{<<urn:iso:std:iso:14812:3.2.1.5>>,vehicle
+      system,vehicle systems}} and/or {{<<urn:iso:std:iso:14812:3.2.1.3>>,personal system,personal
       systems}}
   notes: []
   examples: []

--- a/concepts/concept-3.2.3.5.yaml
+++ b/concepts/concept-3.2.3.5.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS connected unit
   definition:
-  - content: electronic device that is {{urn:iso:std:iso:14812:3.2.3.6,connected}}
+  - content: electronic device that is {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}}
       using one or more communication media
   notes: []
   examples: []

--- a/concepts/concept-3.2.3.6.yaml
+++ b/concepts/concept-3.2.3.6.yaml
@@ -10,13 +10,13 @@ eng:
     normative_status: preferred
     designation: ITS connected
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}}
       that is equipped with enabled (i.e. on) and operational electronic communication
-      technologies to support {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}},
+      technologies to support {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}},
       including the means to send and receive data to and from other connected entities
   notes:
   - content: The term "connected" does not imply support for any specific communications
-      interface or {{urn:iso:std:iso:14812:3.2.9.2,ITS-S application process}}.
+      interface or {{<<urn:iso:std:iso:14812:3.2.9.2>>,ITS-S application process}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.2.4.1.yaml
+++ b/concepts/concept-3.2.4.1.yaml
@@ -13,9 +13,9 @@ eng:
     normative_status: admitted
     designation: external in-vehicle device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.3,personal system}} consisting of global
-      navigation satellite system (GNSS) and/or wireless {{urn:iso:std:iso:14812:3.1.8.7,module,modules}}
-      that are {{urn:iso:std:iso:14812:3.2.3.6,connected}} to a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.3>>,personal system}} consisting of global
+      navigation satellite system (GNSS) and/or wireless {{<<urn:iso:std:iso:14812:3.1.8.7>>,module,modules}}
+      that are {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} to a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       during a trip"
   notes: []
   examples: []

--- a/concepts/concept-3.2.4.2.yaml
+++ b/concepts/concept-3.2.4.2.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS personal information device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.3,personal system}} that enables personal
-      access to {{urn:iso:std:iso:14812:3.6.1.1,traveller}} information"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.3>>,personal system}} that enables personal
+      access to {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller}} information"
   notes: []
   examples:
   - content: Personal computer.

--- a/concepts/concept-3.2.4.3.yaml
+++ b/concepts/concept-3.2.4.3.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS nomadic device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.4.2,personal information device}} that is
-      taken with and can be accessed by the {{urn:iso:std:iso:14812:3.6.1.1,traveller}}
+  - content: "{{<<urn:iso:std:iso:14812:3.2.4.2>>,personal information device}} that is
+      taken with and can be accessed by the {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller}}
       during a journey"
   notes: []
   examples:

--- a/concepts/concept-3.2.4.4.yaml
+++ b/concepts/concept-3.2.4.4.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS public information device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.3,personal system}} that provides {{urn:iso:std:iso:14812:3.5.8.2,commercial,public}}
-      access to {{urn:iso:std:iso:14812:3.6.1.1,traveller}} information"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.3>>,personal system}} that provides {{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial,public}}
+      access to {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller}} information"
   notes: []
   examples:
   - content: Kiosk.

--- a/concepts/concept-3.2.5.1.yaml
+++ b/concepts/concept-3.2.5.1.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: CCMS
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.4,support system}} that enables trusted
-      communications among {{urn:iso:std:iso:14812:3.1.8.2,ITS component,ITS components}}
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.4>>,support system}} that enables trusted
+      communications among {{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS component,ITS components}}
       and protects data from unauthorized access"
   notes: []
   examples: []

--- a/concepts/concept-3.2.5.2.yaml
+++ b/concepts/concept-3.2.5.2.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS map provision system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.4,support system}} that provides map databases
-      used to support {{urn:iso:std:iso:14812:3.5.3.1,ITS service,ITS services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.4>>,support system}} that provides map databases
+      used to support {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service,ITS services}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.6.1.yaml
+++ b/concepts/concept-3.2.6.1.yaml
@@ -16,8 +16,8 @@ eng:
     normative_status: admitted
     designation: onboard equipment
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.1.5,vehicle system}} that provides all ITS
-      functionality on-board the {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.1.5>>,vehicle system}} that provides all ITS
+      functionality on-board the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}"
   notes:
   - content: ITS on-board equipment relates to any functionality. When there is a
       need to distinguish between core functionality and that by a special vehicle,

--- a/concepts/concept-3.2.6.2.yaml
+++ b/concepts/concept-3.2.6.2.yaml
@@ -16,9 +16,9 @@ eng:
     normative_status: admitted
     designation: onboard unit
   definition:
-  - content: part of {{urn:iso:std:iso:14812:3.2.6.1,ITS on-board equipment,on-board
-      equipment}} that provides wireless connectivity to other {{urn:iso:std:iso:14812:3.1.8.2,ITS
-      component,ITS components}} external to the {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: part of {{<<urn:iso:std:iso:14812:3.2.6.1>>,ITS on-board equipment,on-board
+      equipment}} that provides wireless connectivity to other {{<<urn:iso:std:iso:14812:3.1.8.2>>,ITS
+      component,ITS components}} external to the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
   notes:
   - content: An OBU implementation can also include ITS functionality.
   examples: []

--- a/concepts/concept-3.2.7.1.yaml
+++ b/concepts/concept-3.2.7.1.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: BSMD
   definition:
-  - content: abstract {{urn:iso:std:iso:14812:3.1.1.1,entity}} representing a managed
-      processing and memory {{urn:iso:std:iso:14812:3.1.3.11,environment}} that provides
+  - content: abstract {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} representing a managed
+      processing and memory {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment}} that provides
       protection from code and data that has not been determined to meet established
       security requirements
   notes: []

--- a/concepts/concept-3.2.7.2.yaml
+++ b/concepts/concept-3.2.7.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: ITS trust domain
   definition:
-  - content: set of {{urn:iso:std:iso:14812:3.2.7.1,bounded secured managed domain,bounded
+  - content: set of {{<<urn:iso:std:iso:14812:3.2.7.1>>,bounded secured managed domain,bounded
       secured managed domains}} that meet a defined set of ITS industry security requirements
   notes: []
   examples: []

--- a/concepts/concept-3.2.7.3.yaml
+++ b/concepts/concept-3.2.7.3.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.7.1,bounded secured managed domain}} that
-      is able to meet requirements of the {{urn:iso:std:iso:14812:3.2.7.2,ITS trust
+  - content: "{{<<urn:iso:std:iso:14812:3.2.7.1>>,bounded secured managed domain}} that
+      is able to meet requirements of the {{<<urn:iso:std:iso:14812:3.2.7.2>>,ITS trust
       domain}} within which it wishes to participate"
   notes:
   - content: The ITS station reference architecture is defined in <<ref_16,ISO 21217>>.

--- a/concepts/concept-3.2.7.4.yaml
+++ b/concepts/concept-3.2.7.4.yaml
@@ -13,7 +13,7 @@ eng:
     normative_status: preferred
     designation: ITS-SU
   definition:
-  - content: instantiation of an {{urn:iso:std:iso:14812:3.2.7.3,ITS station}}
+  - content: instantiation of an {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.7.5.yaml
+++ b/concepts/concept-3.2.7.5.yaml
@@ -13,8 +13,8 @@ eng:
     normative_status: preferred
     designation: ITS-SCU
   definition:
-  - content: physical unit in an {{urn:iso:std:iso:14812:3.2.7.4,ITS-S unit}} containing
-      part or all of the functionality of an {{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS-S}}
+  - content: physical unit in an {{<<urn:iso:std:iso:14812:3.2.7.4>>,ITS-S unit}} containing
+      part or all of the functionality of an {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS-S}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.7.6.yaml
+++ b/concepts/concept-3.2.7.6.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: ITS-S host
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS-S}} functionalities
-      in an {{urn:iso:std:iso:14812:3.2.7.8,ITS-S node}} other than the functionalities
-      of an {{urn:iso:std:iso:14812:3.2.7.7,ITS-S router}}, ITS-S border router, ITS-S
+  - content: "{{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS-S}} functionalities
+      in an {{<<urn:iso:std:iso:14812:3.2.7.8>>,ITS-S node}} other than the functionalities
+      of an {{<<urn:iso:std:iso:14812:3.2.7.7>>,ITS-S router}}, ITS-S border router, ITS-S
       mobile router or an ITS-S gateway"
   notes:
   - content: ITS-S border router and ITS-S mobile router are ITS-S routers with added

--- a/concepts/concept-3.2.7.7.yaml
+++ b/concepts/concept-3.2.7.7.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S router
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS-S}} functionalities
-      in an {{urn:iso:std:iso:14812:3.2.7.8,ITS-S node}} that enable connecting two
+  - content: "{{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS-S}} functionalities
+      in an {{<<urn:iso:std:iso:14812:3.2.7.8>>,ITS-S node}} that enable connecting two
       networks and forwarding packets not explicitly addressed to the ITS-S node"
   notes: []
   examples: []

--- a/concepts/concept-3.2.7.8.yaml
+++ b/concepts/concept-3.2.7.8.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: ITS-S node
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.5.4,node}} comprised of a set of functionalities
-      in an {{urn:iso:std:iso:14812:3.2.7.4,ITS-S unit}} that is {{urn:iso:std:iso:14812:3.2.3.6,connected}}
-      to the {{urn:iso:std:iso:14812:3.2.7.3,ITS station}}-internal network or comprises
+  - content: "{{<<urn:iso:std:iso:14812:3.3.5.4>>,node}} comprised of a set of functionalities
+      in an {{<<urn:iso:std:iso:14812:3.2.7.4>>,ITS-S unit}} that is {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}}
+      to the {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station}}-internal network or comprises
       an entire ITS-S unit"
   notes: []
   examples: []

--- a/concepts/concept-3.2.8.1.yaml
+++ b/concepts/concept-3.2.8.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS application
   definition:
-  - content: realization of an {{urn:iso:std:iso:14812:3.5.3.1,ITS service}} that
-      involves an association of two or more complementary {{urn:iso:std:iso:14812:3.2.9.2,ITS-S
+  - content: realization of an {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS service}} that
+      involves an association of two or more complementary {{<<urn:iso:std:iso:14812:3.2.9.2>>,ITS-S
       application process,ITS-S application processes}}
   notes: []
   examples: []

--- a/concepts/concept-3.2.8.2.yaml
+++ b/concepts/concept-3.2.8.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: interoperability design
   definition:
-  - content: characteristics necessary to fully define how various {{urn:iso:std:iso:14812:3.1.8.1,physical
-      object,physical objects}} interoperate to provide a {{urn:iso:std:iso:14812:3.5.2.1,service}}
+  - content: characteristics necessary to fully define how various {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical
+      object,physical objects}} interoperate to provide a {{<<urn:iso:std:iso:14812:3.5.2.1>>,service}}
   notes:
   - content: Characteristics often include but are not limited to functional, performance
       and interface requirements.

--- a/concepts/concept-3.2.8.3.yaml
+++ b/concepts/concept-3.2.8.3.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: ITS application specification
   definition:
-  - content: one or more {{urn:iso:std:iso:14812:3.1.6.3,document,documents}} that
-      detail the {{urn:iso:std:iso:14812:3.2.8.2,interoperability design}} for an
-      {{urn:iso:std:iso:14812:3.2.8.1,ITS application}}
+  - content: one or more {{<<urn:iso:std:iso:14812:3.1.6.3>>,document,documents}} that
+      detail the {{<<urn:iso:std:iso:14812:3.2.8.2>>,interoperability design}} for an
+      {{<<urn:iso:std:iso:14812:3.2.8.1>>,ITS application}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.8.4.yaml
+++ b/concepts/concept-3.2.8.4.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS application template
   definition:
-  - content: defined annotated outline for an {{urn:iso:std:iso:14812:3.2.8.3,ITS
+  - content: defined annotated outline for an {{<<urn:iso:std:iso:14812:3.2.8.3>>,ITS
       application specification}}
   notes: []
   examples: []

--- a/concepts/concept-3.2.8.5.yaml
+++ b/concepts/concept-3.2.8.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS implementation
   definition:
-  - content: integration of each {{urn:iso:std:iso:14812:3.1.8.1,physical object}}
-      necessary to implement one or more {{urn:iso:std:iso:14812:3.2.8.1,ITS application,ITS
+  - content: integration of each {{<<urn:iso:std:iso:14812:3.1.8.1>>,physical object}}
+      necessary to implement one or more {{<<urn:iso:std:iso:14812:3.2.8.1>>,ITS application,ITS
       applications}}
   notes:
   - content: An ITS application typically requires multiple components (e.g. an ITS-S
@@ -16,7 +16,7 @@ eng:
       includes a sample of each component necessary for the service but often does
       not represent a complete deployment.
   - content: An ITS implementation is typically used for a laboratory or other experimental
-      {{urn:iso:std:iso:14812:3.1.3.11,environment}} prior to a full-scale deployment.
+      {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment}} prior to a full-scale deployment.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.2.8.6.yaml
+++ b/concepts/concept-3.2.8.6.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: ITS deployment
   definition:
-  - content: installation capable of performing one or more {{urn:iso:std:iso:14812:3.2.8.1,ITS
+  - content: installation capable of performing one or more {{<<urn:iso:std:iso:14812:3.2.8.1>>,ITS
       application,ITS applications}}
   notes:
   - content: An ITS deployment typically refers to the support, central and roadside

--- a/concepts/concept-3.2.9.1.yaml
+++ b/concepts/concept-3.2.9.1.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: ITS application role
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.4.4,ITS-S user need}} expressed as a formal
+  - content: "{{<<urn:iso:std:iso:14812:3.5.4.4>>,ITS-S user need}} expressed as a formal
       set of interoperability requirements that need to be fulfilled to satisfy a
-      portion of functionality of an {{urn:iso:std:iso:14812:3.2.8.1,ITS application}}"
+      portion of functionality of an {{<<urn:iso:std:iso:14812:3.2.8.1>>,ITS application}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.9.2.yaml
+++ b/concepts/concept-3.2.9.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S application process
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.3.10,element}} in an {{urn:iso:std:iso:14812:3.2.7.3,ITS
-      station}} that performs information processing for an {{urn:iso:std:iso:14812:3.5.4.1,ITS-S
+  - content: "{{<<urn:iso:std:iso:14812:3.1.3.10>>,element}} in an {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS
+      station}} that performs information processing for an {{<<urn:iso:std:iso:14812:3.5.4.1>>,ITS-S
       service}}"
   notes: []
   examples: []

--- a/concepts/concept-3.2.9.3.yaml
+++ b/concepts/concept-3.2.9.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S application
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.9.2,ITS-S application process}} residing
-      in the {{urn:iso:std:iso:14812:3.1.5.1,application entity}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.9.2>>,ITS-S application process}} residing
+      in the {{<<urn:iso:std:iso:14812:3.1.5.1>>,application entity}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.2.9.4.yaml
+++ b/concepts/concept-3.2.9.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S application implementation
   definition:
-  - content: implementation of an {{urn:iso:std:iso:14812:3.2.9.2,ITS-S application
-      process}} within the {{urn:iso:std:iso:14812:3.1.5.1,application entity}}
+  - content: implementation of an {{<<urn:iso:std:iso:14812:3.2.9.2>>,ITS-S application
+      process}} within the {{<<urn:iso:std:iso:14812:3.1.5.1>>,application entity}}
   notes:
   - content: An implementation is typically associated with an implementation name,
       a version and release number.

--- a/concepts/concept-3.2.9.5.yaml
+++ b/concepts/concept-3.2.9.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S application process installation
   definition:
-  - content: installation of an implementation of an {{urn:iso:std:iso:14812:3.2.9.2,ITS-S
-      application process}} on an {{urn:iso:std:iso:14812:3.2.7.3,ITS station}}
+  - content: installation of an implementation of an {{<<urn:iso:std:iso:14812:3.2.9.2>>,ITS-S
+      application process}} on an {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station}}
   notes:
   - content: An implementation is typically associated with an implementation name,
       a version and release number.

--- a/concepts/concept-3.2.9.6.yaml
+++ b/concepts/concept-3.2.9.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ITS-S application installation
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.9.5,ITS-S application process installation}}
-      within the {{urn:iso:std:iso:14812:3.1.5.1,application entity}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.9.5>>,ITS-S application process installation}}
+      within the {{<<urn:iso:std:iso:14812:3.1.5.1>>,application entity}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.1.yaml
+++ b/concepts/concept-3.3.1.1.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: cross-section
   definition:
-  - content: transverse view of {{urn:iso:std:iso:14812:3.3.5.1,road}} geometry
+  - content: transverse view of {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} geometry
   notes:
-  - content: The transverse view provides a vertical section of the ground and {{urn:iso:std:iso:14812:3.3.1.5,carriageway}}
+  - content: The transverse view provides a vertical section of the ground and {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}}
       at right angles to the centre line of the carriageway.
   examples:
   - content: "<<fig_A.23>>."

--- a/concepts/concept-3.3.1.10.yaml
+++ b/concepts/concept-3.3.1.10.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: roadside
   definition:
-  - content: portion of the {{urn:iso:std:iso:14812:3.3.1.2,road reservation}} excluding
-      all {{urn:iso:std:iso:14812:3.3.1.3,roadway}} and {{urn:iso:std:iso:14812:3.3.1.4,driving
+  - content: portion of the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}} excluding
+      all {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} and {{<<urn:iso:std:iso:14812:3.3.1.4>>,driving
       space,driving space(s)}}
   notes:
-  - content: Roadside, {{urn:iso:std:iso:14812:3.3.1.18,shoulder}} and {{urn:iso:std:iso:14812:3.3.1.11,verge}}
+  - content: Roadside, {{<<urn:iso:std:iso:14812:3.3.1.18>>,shoulder}} and {{<<urn:iso:std:iso:14812:3.3.1.11>>,verge}}
       define similar but slightly different concepts
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.11.yaml
+++ b/concepts/concept-3.3.1.11.yaml
@@ -7,13 +7,13 @@ eng:
     normative_status: preferred
     designation: verge
   definition:
-  - content: unpaved part of the {{urn:iso:std:iso:14812:3.3.1.10,roadside}} designed
+  - content: unpaved part of the {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}} designed
       for travel safety purposes
   notes:
-  - content: A verge can separate two {{urn:iso:std:iso:14812:3.3.1.13,lane,lanes}}
-      of different modes, separate a {{urn:iso:std:iso:14812:3.3.1.13,traffic lane}}
+  - content: A verge can separate two {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane,lanes}}
+      of different modes, separate a {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}}
       from a ditch, or separate a lane from another safety hazard.
-  - content: Roadside, {{urn:iso:std:iso:14812:3.3.1.18,shoulder}} and verge define
+  - content: Roadside, {{<<urn:iso:std:iso:14812:3.3.1.18>>,shoulder}} and verge define
       similar but slightly different concepts.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.12.yaml
+++ b/concepts/concept-3.3.1.12.yaml
@@ -11,19 +11,19 @@ eng:
     designation: generic lane
   domain: generic
   definition:
-  - content: portion of {{urn:iso:std:iso:14812:3.3.1.2,road reservation}} intended
-      to accommodate a single line of moving {{urn:iso:std:iso:14812:3.1.1.3,material
+  - content: portion of {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}} intended
+      to accommodate a single line of moving {{<<urn:iso:std:iso:14812:3.1.1.3>>,material
       entity,material entities}} along its length
   notes:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,lane,Lanes}} are often bounded by lane
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,lane,Lanes}} are often bounded by lane
       markings."
   - content: Lanes may be significantly wider than the normal vehicle width to allow
       variance in lane position of the vehicle as well as for various vehicle dimensions.
-  - content: The "lane" nomenclature typically refers to {{urn:iso:std:iso:14812:3.7.6.3,motor
-      vehicle}} usage, but can also refer to other purposes, such as {{urn:iso:std:iso:14812:3.3.3.4,sidewalk,sidewalks}}.
+  - content: The "lane" nomenclature typically refers to {{<<urn:iso:std:iso:14812:3.7.6.3>>,motor
+      vehicle}} usage, but can also refer to other purposes, such as {{<<urn:iso:std:iso:14812:3.3.3.4>>,sidewalk,sidewalks}}.
   examples:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,traffic lane,Traffic lane}}, {{urn:iso:std:iso:14812:3.3.3.1,cycle
-      lane}}, {{urn:iso:std:iso:14812:3.3.3.4,sidewalk}}."
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane,Traffic lane}}, {{<<urn:iso:std:iso:14812:3.3.3.1>>,cycle
+      lane}}, {{<<urn:iso:std:iso:14812:3.3.3.4>>,sidewalk}}."
   language_code: eng
   entry_status: valid
   sources:

--- a/concepts/concept-3.3.1.13.yaml
+++ b/concepts/concept-3.3.1.13.yaml
@@ -10,13 +10,13 @@ eng:
     normative_status: preferred
     designation: lane
   definition:
-  - content: portion of {{urn:iso:std:iso:14812:3.3.1.5,carriageway}} designed to
-      accommodate a single line of moving {{urn:iso:std:iso:14812:3.7.6.1,road vehicle,road
+  - content: portion of {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}} designed to
+      accommodate a single line of moving {{<<urn:iso:std:iso:14812:3.7.6.1>>,road vehicle,road
       vehicles}}
   notes:
   - content: The term "lane" is often used to refer to a "traffic lane" when the context
       is known to be "traffic".
-  - content: A traffic lane can be bi-directional, such as a single lane {{urn:iso:std:iso:14812:3.3.5.1,road}},
+  - content: A traffic lane can be bi-directional, such as a single lane {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}},
       a two-way turn/overtaking lane, or a reversible flow lane.
   - content: Some jurisdictions allow supplemental uses of a traffic lane, such as
       multiple motorcycles sharing the width of a traffic lane or allowing a bicycle

--- a/concepts/concept-3.3.1.14.yaml
+++ b/concepts/concept-3.3.1.14.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: reserved lane
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,traffic lane}} restricted to a specific
-      subset of {{urn:iso:std:iso:14812:3.7.6.1,road vehicle,road vehicles}} or {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}} restricted to a specific
+      subset of {{<<urn:iso:std:iso:14812:3.7.6.1>>,road vehicle,road vehicles}} or {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
       categories"
   notes:
   - content: A traffic lane may be reserved permanently or under certain conditions

--- a/concepts/concept-3.3.1.15.yaml
+++ b/concepts/concept-3.3.1.15.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: usable width
   definition:
-  - content: all {{urn:iso:std:iso:14812:3.3.1.13,traffic lane,traffic lanes}} of
-      a {{urn:iso:std:iso:14812:3.3.1.5,carriageway}}
+  - content: all {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane,traffic lanes}} of
+      a {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.16.yaml
+++ b/concepts/concept-3.3.1.16.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: lay-by
   definition:
-  - content: short length of paved {{urn:iso:std:iso:14812:3.3.1.5,carriageway}} at
-      its edge designed to allow a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} to draw
-      out of the {{urn:iso:std:iso:14812:3.3.1.13,traffic lane,traffic lanes}} and
+  - content: short length of paved {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}} at
+      its edge designed to allow a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} to draw
+      out of the {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane,traffic lanes}} and
       stop temporarily
   notes:
-  - content: Lay-bys are not part of a {{urn:iso:std:iso:14812:3.3.1.19,hard shoulder}}.
+  - content: Lay-bys are not part of a {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard shoulder}}.
   - content: Lay-bys can be used for emergency situations, picking up/dropping off
-      {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}, etc.
+      {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}, etc.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.3.1.17.yaml
+++ b/concepts/concept-3.3.1.17.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: hardstanding
   definition:
-  - content: part of a paved {{urn:iso:std:iso:14812:3.3.1.5,carriageway}} that is
-      not a {{urn:iso:std:iso:14812:3.3.1.13,traffic lane}}, {{urn:iso:std:iso:14812:3.3.1.19,hard
-      shoulder}}, or {{urn:iso:std:iso:14812:3.3.1.16,lay-by}}.
+  - content: part of a paved {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}} that is
+      not a {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}}, {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard
+      shoulder}}, or {{<<urn:iso:std:iso:14812:3.3.1.16>>,lay-by}}.
   notes:
   - content: Hardstanding can include edges of a hard shoulder outside of designated
-      lane markings, slips for future connector {{urn:iso:std:iso:14812:3.3.5.1,road,roads}},
+      lane markings, slips for future connector {{<<urn:iso:std:iso:14812:3.3.5.1>>,road,roads}},
       etc.
   examples:
   - content: See <<fig_A.23>>.

--- a/concepts/concept-3.3.1.18.yaml
+++ b/concepts/concept-3.3.1.18.yaml
@@ -7,13 +7,13 @@ eng:
     normative_status: preferred
     designation: shoulder
   definition:
-  - content: either a {{urn:iso:std:iso:14812:3.3.1.19,hard shoulder}} or a {{urn:iso:std:iso:14812:3.3.1.20,soft
+  - content: either a {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard shoulder}} or a {{<<urn:iso:std:iso:14812:3.3.1.20>>,soft
       shoulder}}
   notes:
   - content: In some jurisdictions, a shoulder can be used for emergency stops and/or
       other purposes in addition to providing a clear zone for safety purposes.
-  - content: "{{urn:iso:std:iso:14812:3.3.1.10,roadside,Roadside}}, shoulder, and
-      {{urn:iso:std:iso:14812:3.3.1.11,verge}} define similar but slightly different
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside,Roadside}}, shoulder, and
+      {{<<urn:iso:std:iso:14812:3.3.1.11>>,verge}} define similar but slightly different
       concepts"
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.19.yaml
+++ b/concepts/concept-3.3.1.19.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: hard shoulder
   definition:
-  - content: part of the paved {{urn:iso:std:iso:14812:3.3.1.5,carriageway}} designed
+  - content: part of the paved {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}} designed
       to support traffic loads but not normally intended for driving
   notes:
-  - content: A hard shoulder can be narrow or wide enough for a {{urn:iso:std:iso:14812:3.3.1.13,traffic
+  - content: A hard shoulder can be narrow or wide enough for a {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic
       lane}}.
   - content: A hard shoulder can have a surface that discourages usage as a driving
       surface in some countries.

--- a/concepts/concept-3.3.1.2.yaml
+++ b/concepts/concept-3.3.1.2.yaml
@@ -10,15 +10,15 @@ eng:
     normative_status: preferred
     designation: easement
   definition:
-  - content: area legally reserved for {{urn:iso:std:iso:14812:3.3.5.1,road}} transport
+  - content: area legally reserved for {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} transport
       purposes and support
   notes:
   - content: Support includes physical equipment such as safety devices, signage and
       controller cabinets as well as access by maintenance vehicles and personnel.
-  - content: The road reservation includes all {{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}}
-      as well as width to allow for {{urn:iso:std:iso:14812:3.3.1.10,roadside}} devices,
-      {{urn:iso:std:iso:14812:3.3.1.18,shoulder,shoulders}}, {{urn:iso:std:iso:14812:3.3.1.11,verge,verges}},
-      {{urn:iso:std:iso:14812:3.3.3.3,footway,footways}}, drainage facilities, sound
+  - content: The road reservation includes all {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}}
+      as well as width to allow for {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}} devices,
+      {{<<urn:iso:std:iso:14812:3.3.1.18>>,shoulder,shoulders}}, {{<<urn:iso:std:iso:14812:3.3.1.11>>,verge,verges}},
+      {{<<urn:iso:std:iso:14812:3.3.3.3>>,footway,footways}}, drainage facilities, sound
       walls, slopes, embankments, etc.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.20.yaml
+++ b/concepts/concept-3.3.1.20.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: soft shoulder
   definition:
-  - content: unpaved part of the {{urn:iso:std:iso:14812:3.3.1.2,road reservation}}
-      not belonging to the {{urn:iso:std:iso:14812:3.3.1.5,carriageway}} but providing
+  - content: unpaved part of the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}}
+      not belonging to the {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}} but providing
       lateral support to it
   notes:
   - content: Soft shoulders are not normally intended for driving.

--- a/concepts/concept-3.3.1.3.yaml
+++ b/concepts/concept-3.3.1.3.yaml
@@ -7,23 +7,23 @@ eng:
     normative_status: preferred
     designation: roadway
   definition:
-  - content: part of the surface of the {{urn:iso:std:iso:14812:3.3.1.2,road reservation}}
-      primarily designed for the movement of {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}}
+  - content: part of the surface of the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}}
+      primarily designed for the movement of {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}}
       that conform to a specified set of requirements
   notes:
-  - content: A roadway is characterized using a {{urn:iso:std:iso:14812:3.3.1.1,cross-section}}
+  - content: A roadway is characterized using a {{<<urn:iso:std:iso:14812:3.3.1.1>>,cross-section}}
       of a road facility as the roadway characteristics often change along the length
-      of the road. See "{{urn:iso:std:iso:14812:3.3.5.1,road}}", "{{urn:iso:std:iso:14812:3.3.5.7,road
-      section}}", "{{urn:iso:std:iso:14812:3.3.5.8,road segment}}", and "{{urn:iso:std:iso:14812:3.3.5.6,road
+      of the road. See "{{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}", "{{<<urn:iso:std:iso:14812:3.3.5.7>>,road
+      section}}", "{{<<urn:iso:std:iso:14812:3.3.5.8>>,road segment}}", and "{{<<urn:iso:std:iso:14812:3.3.5.6>>,road
       link,road links}}" for different types of stretches of roadway.
   - content: In practice, the roadway design considers a variety of issues, which
       can result in suboptimal road segments that violate normal design guidelines.
-      Such {{urn:iso:std:iso:14812:3.4.1.1,location,locations}} are typically posted
+      Such {{<<urn:iso:std:iso:14812:3.4.1.1>>,location,locations}} are typically posted
       with warning signs, but they are still designed for the movement of vehicles.
   - content: While the roadway is designed with certain vehicle characteristics in
       mind, local regulations typically allow a wider set of vehicles to use the roadway.
-  - content: The roadway includes any contiguous {{urn:iso:std:iso:14812:3.3.1.19,hard
-      shoulder}}, {{urn:iso:std:iso:14812:3.3.1.17,hardstanding}} and {{urn:iso:std:iso:14812:3.3.1.14,reserved
+  - content: The roadway includes any contiguous {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard
+      shoulder}}, {{<<urn:iso:std:iso:14812:3.3.1.17>>,hardstanding}} and {{<<urn:iso:std:iso:14812:3.3.1.14>>,reserved
       lane,reserved lanes}}.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.4.yaml
+++ b/concepts/concept-3.3.1.4.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: driving space
   definition:
-  - content: area above the {{urn:iso:std:iso:14812:3.3.1.3,roadway}} that is primarily
-      designed for the movement of {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}}
+  - content: area above the {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} that is primarily
+      designed for the movement of {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}}
   notes:
   - content: In practice, the driving space design considers a variety of issues,
-      which can result in suboptimal {{urn:iso:std:iso:14812:3.3.5.1,road}} segments
-      that violate normal design guidelines. Such {{urn:iso:std:iso:14812:3.4.1.1,location,locations}}
+      which can result in suboptimal {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} segments
+      that violate normal design guidelines. Such {{<<urn:iso:std:iso:14812:3.4.1.1>>,location,locations}}
       are typically posted with warning signs, but they are still designed for the
       movement of vehicles.
   - content: While the driving space is designed with certain vehicle characteristics

--- a/concepts/concept-3.3.1.5.yaml
+++ b/concepts/concept-3.3.1.5.yaml
@@ -7,16 +7,16 @@ eng:
     normative_status: preferred
     designation: carriageway
   definition:
-  - content: contiguous area of {{urn:iso:std:iso:14812:3.3.1.3,roadway}} along a
-      {{urn:iso:std:iso:14812:3.3.5.8,road segment}}
+  - content: contiguous area of {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} along a
+      {{<<urn:iso:std:iso:14812:3.3.5.8>>,road segment}}
   notes:
-  - content: A carriageway is comprised of one or more traffic {{urn:iso:std:iso:14812:3.3.1.13,traffic
-      lane,lanes}} [i.e. the {{urn:iso:std:iso:14812:3.3.1.15,usable width}}] and
-      could include {{urn:iso:std:iso:14812:3.3.1.18,shoulder,shoulders}} and {{urn:iso:std:iso:14812:3.3.1.16,lay-by,lay-bys}}.
-  - content: Carriageways are separated by {{urn:iso:std:iso:14812:3.3.2.1,physical
+  - content: A carriageway is comprised of one or more traffic {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic
+      lane,lanes}} [i.e. the {{<<urn:iso:std:iso:14812:3.3.1.15>>,usable width}}] and
+      could include {{<<urn:iso:std:iso:14812:3.3.1.18>>,shoulder,shoulders}} and {{<<urn:iso:std:iso:14812:3.3.1.16>>,lay-by,lay-bys}}.
+  - content: Carriageways are separated by {{<<urn:iso:std:iso:14812:3.3.2.1>>,physical
       traffic separator,physical traffic separators}}.
-  - content: When looking at a {{urn:iso:std:iso:14812:3.3.1.1,cross-section}} of
-      the {{urn:iso:std:iso:14812:3.3.1.2,road reservation}}, the roadway consists
+  - content: When looking at a {{<<urn:iso:std:iso:14812:3.3.1.1>>,cross-section}} of
+      the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}}, the roadway consists
       of all of the carriageways.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.6.yaml
+++ b/concepts/concept-3.3.1.6.yaml
@@ -7,19 +7,19 @@ eng:
     normative_status: preferred
     designation: travelled way
   definition:
-  - content: part of the {{urn:iso:std:iso:14812:3.3.1.3,roadway}} that is currently
+  - content: part of the {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} that is currently
       intended for transport purposes
   notes:
-  - content: The travelled way does not include {{urn:iso:std:iso:14812:3.3.1.19,hard
-      shoulder,hard shoulders}}, {{urn:iso:std:iso:14812:3.3.1.17,hardstanding}},
+  - content: The travelled way does not include {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard
+      shoulder,hard shoulders}}, {{<<urn:iso:std:iso:14812:3.3.1.17>>,hardstanding}},
       or other areas that are not currently intended for normal operational use. In
       other words, while these other areas are "designed" for transport purposes,
       they are not "intended" for normal transport purposes (at present); rather these
       extra areas exist for safety and other exceptional use conditions.
   - content: While the limits of the roadway are defined by the design of the physical
       infrastructure and are generally static; the limits of the travelled way can
-      be dynamic, such as in the case of a {{urn:iso:std:iso:14812:3.3.4.1,hard shoulder
-      for emergency use}} being converted into {{urn:iso:std:iso:14812:3.3.4.2,hard
+      be dynamic, such as in the case of a {{<<urn:iso:std:iso:14812:3.3.4.1>>,hard shoulder
+      for emergency use}} being converted into {{<<urn:iso:std:iso:14812:3.3.4.2>>,hard
       shoulder running}} operation.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.1.7.yaml
+++ b/concepts/concept-3.3.1.7.yaml
@@ -16,14 +16,14 @@ eng:
     normative_status: admitted
     designation: undivided highway
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.3,roadway}} comprised of exactly one {{urn:iso:std:iso:14812:3.3.1.5,carriageway}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} comprised of exactly one {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}}"
   notes:
   - content: The World Road Association (PIARC) term is "single carriageway road"
       and is recognized as a preferred term. As per the definitions provided in this
       document, "single carriageway road segment" is more accurate and is the most
       preferred term. The term "single carriageway" by itself is not preferred but
       admitted.
-  - content: A single carriageway road segment could have multiple {{urn:iso:std:iso:14812:3.3.1.13,lane,lanes}}
+  - content: A single carriageway road segment could have multiple {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane,lanes}}
       and could allow travel in opposite directions
   - content: The term "undivided highway" is the equivalent American English term.
   examples: []

--- a/concepts/concept-3.3.1.8.yaml
+++ b/concepts/concept-3.3.1.8.yaml
@@ -16,7 +16,7 @@ eng:
     normative_status: admitted
     designation: dual carriageway
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.3,roadway}} comprised of exactly two {{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} comprised of exactly two {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}}"
   notes:
   - content: The PIARC term is "dual carriageway road" and is recognized as a preferred
       term. As per the definitions provided in this document, "dual carriageway road

--- a/concepts/concept-3.3.1.9.yaml
+++ b/concepts/concept-3.3.1.9.yaml
@@ -13,11 +13,11 @@ eng:
     normative_status: admitted
     designation: multiple carriageway
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.3,roadway}} comprised of more than two
-      {{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} comprised of more than two
+      {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}}"
   notes:
   - content: The PIARC term is "multiple carriageway road" and is recognized as a
-      preferred term. As per the definitions provided in this document, "{{urn:iso:std:iso:14812:3.3.1.8,dual
+      preferred term. As per the definitions provided in this document, "{{<<urn:iso:std:iso:14812:3.3.1.8>>,dual
       carriageway road segment}}" is more accurate and is the most preferred term.
       The term "dual carriageway" by itself is not preferred but admitted.
   - content: The separate carriageways are typically designed for separate traffic

--- a/concepts/concept-3.3.2.1.yaml
+++ b/concepts/concept-3.3.2.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: physical traffic separator
   definition:
-  - content: mechanism used to physically separate {{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}}
+  - content: mechanism used to physically separate {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}}
   notes:
   - content: Mechanisms include various types of barriers, such as walls, rails, pylons,
       kerbs and ditches, as well as open, unpaved space. If two streams of traffic

--- a/concepts/concept-3.3.2.2.yaml
+++ b/concepts/concept-3.3.2.2.yaml
@@ -16,8 +16,8 @@ eng:
     normative_status: admitted
     designation: neutral ground
   definition:
-  - content: part of the {{urn:iso:std:iso:14812:3.3.1.2,road reservation}} between
-      {{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}} designed for travel
+  - content: part of the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road reservation}} between
+      {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}} designed for travel
       safety purposes
   notes:
   - content: A central reservation can be paved or unpaved and can be equipped with

--- a/concepts/concept-3.3.2.3.yaml
+++ b/concepts/concept-3.3.2.3.yaml
@@ -13,9 +13,9 @@ eng:
     normative_status: admitted
     designation: concrete barrier
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.2.1,physical traffic separator}} that consists
-      of a wall with a wide, sloped base designed to divert {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}}
-      back into their {{urn:iso:std:iso:14812:3.3.1.13,traffic lane}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.2.1>>,physical traffic separator}} that consists
+      of a wall with a wide, sloped base designed to divert {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}}
+      back into their {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}}"
   notes:
   - content: Jersey barriers are typically modular. They are typically made of concrete
       but can also be made with other materials such as plastic filled with water

--- a/concepts/concept-3.3.3.1.yaml
+++ b/concepts/concept-3.3.3.1.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: cycle lane
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,lane}} designed for the through movement
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,lane}} designed for the through movement
       of cycles"
   notes:
-  - content: Cycle lanes are typically much narrower than {{urn:iso:std:iso:14812:3.3.1.13,traffic
+  - content: Cycle lanes are typically much narrower than {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic
       lane,traffic lanes}}.
-  - content: Cycle lanes are typically part of either a {{urn:iso:std:iso:14812:3.3.1.15,usable
-      width,carriageway}} or a {{urn:iso:std:iso:14812:3.3.3.2,cycleway}}.
-  - content: Cycle lanes could also allow and be designed for {{urn:iso:std:iso:14812:3.7.6.2,motorized
+  - content: Cycle lanes are typically part of either a {{<<urn:iso:std:iso:14812:3.3.1.15>>,usable
+      width,carriageway}} or a {{<<urn:iso:std:iso:14812:3.3.3.2>>,cycleway}}.
+  - content: Cycle lanes could also allow and be designed for {{<<urn:iso:std:iso:14812:3.7.6.2>>,motorized
       vehicle,motorized vehicles}} (e.g. e-scooters, mopeds, etc.) with similar performance
       characteristics as human-powered cycles, subject to local regulations.
   examples: []

--- a/concepts/concept-3.3.3.2.yaml
+++ b/concepts/concept-3.3.3.2.yaml
@@ -11,11 +11,11 @@ eng:
     designation: cycle track
   definition:
   - content: infrastructure primarily designed for the use of cycles and separate
-      from a {{urn:iso:std:iso:14812:3.3.1.5,carriageway}}
+      from a {{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway}}
   notes:
-  - content: Local legislation can allow cycleways to be used by a variety of {{urn:iso:std:iso:14812:3.7.5.2,low-speed
+  - content: Local legislation can allow cycleways to be used by a variety of {{<<urn:iso:std:iso:14812:3.7.5.2>>,low-speed
       vehicle,low-speed vehicles}} (e.g. low-speed scooters, skateboards, etc.) and
-      can share usage of other low-speed modes such as {{urn:iso:std:iso:14812:3.6.1.3,pedestrian,pedestrians}},
+      can share usage of other low-speed modes such as {{<<urn:iso:std:iso:14812:3.6.1.3>>,pedestrian,pedestrians}},
       horseback riders, etc.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.3.3.yaml
+++ b/concepts/concept-3.3.3.3.yaml
@@ -13,12 +13,12 @@ eng:
     normative_status: admitted
     designation: pavement
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,lane}} primarily designed for the movement
-      of {{urn:iso:std:iso:14812:3.6.1.3,pedestrian,pedestrians}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,lane}} primarily designed for the movement
+      of {{<<urn:iso:std:iso:14812:3.6.1.3>>,pedestrian,pedestrians}}"
   notes:
   - content: A paved footway is called a "pavement" in British English.
   - content: Regulations typically allow footways to be used by other ultra-low speed
-      {{urn:iso:std:iso:14812:3.5.3.4,user,users}}, such as the users of wheelchairs
+      {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}}, such as the users of wheelchairs
       and strollers.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.3.4.yaml
+++ b/concepts/concept-3.3.3.4.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: sidewalk
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.3.3,footway}} along a {{urn:iso:std:iso:14812:3.3.1.10,roadside}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.3.3>>,footway}} along a {{<<urn:iso:std:iso:14812:3.3.1.10>>,roadside}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.4.1.yaml
+++ b/concepts/concept-3.3.4.1.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: hard shoulder for emergency use
   definition:
-  - content: operating mode of a {{urn:iso:std:iso:14812:3.3.1.19,hard shoulder}}
+  - content: operating mode of a {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard shoulder}}
       that allows operation of emergency, construction, maintenance, or other special
-      use {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}} or for emergency stopping
+      use {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}} or for emergency stopping
       and is prohibited for other vehicle usage
   notes: []
   examples: []

--- a/concepts/concept-3.3.4.2.yaml
+++ b/concepts/concept-3.3.4.2.yaml
@@ -8,10 +8,10 @@ eng:
     designation: hard shoulder running
   definition:
   - content: |-
-      operating mode of a {{urn:iso:std:iso:14812:3.3.1.19,hard shoulder}} that
+      operating mode of a {{<<urn:iso:std:iso:14812:3.3.1.19>>,hard shoulder}} that
       allows operation of general-purpose
-      {{urn:iso:std:iso:14812:3.7.6.3,motor vehicle,motor vehicles}} as an extra
-      {{urn:iso:std:iso:14812:3.3.1.13,lane}}
+      {{<<urn:iso:std:iso:14812:3.7.6.3>>,motor vehicle,motor vehicles}} as an extra
+      {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.5.1.yaml
+++ b/concepts/concept-3.3.5.1.yaml
@@ -7,13 +7,13 @@ eng:
     normative_status: preferred
     designation: road
   definition:
-  - content: curvilinear length of {{urn:iso:std:iso:14812:3.3.1.3,roadway}} that
+  - content: curvilinear length of {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} that
       shares the same identification
   notes:
-  - content: A length of the {{urn:iso:std:iso:14812:3.3.5.2,road network}} may be
+  - content: A length of the {{<<urn:iso:std:iso:14812:3.3.5.2>>,road network}} may be
       referenced by multiple designators (e.g. Main Street and Route 7). In this case,
-      there would be two "roads" that share the same set of "{{urn:iso:std:iso:14812:3.3.1.5,carriageway,carriageways}}".
-  - content: A road can change directions at a {{urn:iso:std:iso:14812:3.3.6.2,junction}}.
+      there would be two "roads" that share the same set of "{{<<urn:iso:std:iso:14812:3.3.1.5>>,carriageway,carriageways}}".
+  - content: A road can change directions at a {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}}.
   - content: The identification is generally a name or number.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.5.10.yaml
+++ b/concepts/concept-3.3.5.10.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: lane segment
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.5.1,road,link}} that represents a contiguous
-      length of a {{urn:iso:std:iso:14812:3.3.5.9,lane link}} characterized by the
+  - content: "{{<<urn:iso:std:iso:14812:3.3.5.1>>,road,link}} that represents a contiguous
+      length of a {{<<urn:iso:std:iso:14812:3.3.5.9>>,lane link}} characterized by the
       same physical characteristics"
   notes: []
   examples: []

--- a/concepts/concept-3.3.5.2.yaml
+++ b/concepts/concept-3.3.5.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: road network
   definition:
-  - content: interconnected collection of {{urn:iso:std:iso:14812:3.3.5.1,road,roads}}
+  - content: interconnected collection of {{<<urn:iso:std:iso:14812:3.3.5.1>>,road,roads}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.5.3.yaml
+++ b/concepts/concept-3.3.5.3.yaml
@@ -7,13 +7,13 @@ eng:
     normative_status: preferred
     designation: road model
   definition:
-  - content: representation of a {{urn:iso:std:iso:14812:3.3.5.2,road network}}
+  - content: representation of a {{<<urn:iso:std:iso:14812:3.3.5.2>>,road network}}
   notes:
-  - content: Road models for different {{urn:iso:std:iso:14812:3.1.2.1,system,systems}}
-      will often define different models. For example, a public {{urn:iso:std:iso:14812:3.1.2.2,transport
-      system}} can define {{urn:iso:std:iso:14812:3.3.5.6,road link,road links}} based
-      on the {{urn:iso:std:iso:14812:3.4.1.1,location}} of bus stops while a traffic
-      system can define road links based on the location of {{urn:iso:std:iso:14812:3.3.6.2,junction,junctions}}.
+  - content: Road models for different {{<<urn:iso:std:iso:14812:3.1.2.1>>,system,systems}}
+      will often define different models. For example, a public {{<<urn:iso:std:iso:14812:3.1.2.2>>,transport
+      system}} can define {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link,road links}} based
+      on the {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}} of bus stops while a traffic
+      system can define road links based on the location of {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction,junctions}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.3.5.4.yaml
+++ b/concepts/concept-3.3.5.4.yaml
@@ -11,13 +11,13 @@ eng:
     designation: road network node
   domain: road network
   definition:
-  - content: component of a {{urn:iso:std:iso:14812:3.3.5.3,road model}} representing
-      a {{urn:iso:std:iso:14812:3.4.1.3,point location}} of the {{urn:iso:std:iso:14812:3.3.5.2,road
+  - content: component of a {{<<urn:iso:std:iso:14812:3.3.5.3>>,road model}} representing
+      a {{<<urn:iso:std:iso:14812:3.4.1.3>>,point location}} of the {{<<urn:iso:std:iso:14812:3.3.5.2>>,road
       network}} graph
   notes:
-  - content: The point location typically represents a point along the {{urn:iso:std:iso:14812:3.3.5.1,road}}
-      which can be used to designate the {{urn:iso:std:iso:14812:3.4.1.1,location}}
-      of a {{urn:iso:std:iso:14812:3.3.6.2,junction}}, {{urn:iso:std:iso:14812:3.5.6.1,public
+  - content: The point location typically represents a point along the {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}
+      which can be used to designate the {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}}
+      of a {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}}, {{<<urn:iso:std:iso:14812:3.5.6.1>>,public
       transport}} stop, jurisdictional boundary, termination point, etc.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.5.5.yaml
+++ b/concepts/concept-3.3.5.5.yaml
@@ -8,8 +8,8 @@ eng:
     designation: link
   domain: road network
   definition:
-  - content: component of a {{urn:iso:std:iso:14812:3.3.5.3,road model}} that represents
-      a connection between two {{urn:iso:std:iso:14812:3.3.5.4,node,nodes}}
+  - content: component of a {{<<urn:iso:std:iso:14812:3.3.5.3>>,road model}} that represents
+      a connection between two {{<<urn:iso:std:iso:14812:3.3.5.4>>,node,nodes}}
   notes:
   - content: A link can be curvilinear and can have various attributes such as width.
   examples: []

--- a/concepts/concept-3.3.5.6.yaml
+++ b/concepts/concept-3.3.5.6.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: road link
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.5.5,link}} representing a contiguous length
-      of a {{urn:iso:std:iso:14812:3.3.5.1,road}} between two {{urn:iso:std:iso:14812:3.3.5.4,node,nodes}}
+  - content: "{{<<urn:iso:std:iso:14812:3.3.5.5>>,link}} representing a contiguous length
+      of a {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}} between two {{<<urn:iso:std:iso:14812:3.3.5.4>>,node,nodes}}
       of operational or managerial significance"
   notes:
   - content: The operational characteristics of the nodes would relate to the type
-      of {{urn:iso:std:iso:14812:3.3.5.3,road model}}. For example, a traffic {{urn:iso:std:iso:14812:3.1.2.1,system}}
-      can base its road links on nodes that represent {{urn:iso:std:iso:14812:3.3.6.2,junction,junctions}}
-      and road {{urn:iso:std:iso:14812:3.1.8.3,terminator,terminators}}.
+      of {{<<urn:iso:std:iso:14812:3.3.5.3>>,road model}}. For example, a traffic {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
+      can base its road links on nodes that represent {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction,junctions}}
+      and road {{<<urn:iso:std:iso:14812:3.1.8.3>>,terminator,terminators}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.3.5.7.yaml
+++ b/concepts/concept-3.3.5.7.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: road section
   definition:
-  - content: aggregation of one or more {{urn:iso:std:iso:14812:3.3.5.6,road link,road
-      links}} that represents a contiguous length of a {{urn:iso:std:iso:14812:3.3.5.1,road}}
+  - content: aggregation of one or more {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link,road
+      links}} that represents a contiguous length of a {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}
       that shares the same management and operational strategies
   notes:
-  - content: Different {{urn:iso:std:iso:14812:3.3.5.3,road model,road models}} can
+  - content: Different {{<<urn:iso:std:iso:14812:3.3.5.3>>,road model,road models}} can
       divide the same road into different road sections.
   examples:
   - content: A traffic signal timing plan is applied to one road section.

--- a/concepts/concept-3.3.5.8.yaml
+++ b/concepts/concept-3.3.5.8.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: road segment
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.5.5,link}} that represents a contiguous
-      length of a {{urn:iso:std:iso:14812:3.3.5.6,road link}} characterized by the
+  - content: "{{<<urn:iso:std:iso:14812:3.3.5.5>>,link}} that represents a contiguous
+      length of a {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link}} characterized by the
       same physical characteristics"
   notes:
   - content: The definition of road segments is highly dependent on which characteristics
       are modelled by the implementation. Characteristics that can result in a new
-      road segment include addition or subtraction of a {{urn:iso:std:iso:14812:3.3.1.13,lane}},
-      a change in {{urn:iso:std:iso:14812:3.3.1.3,roadway}} width, the change of {{urn:iso:std:iso:14812:3.3.5.1,road}}
+      road segment include addition or subtraction of a {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane}},
+      a change in {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} width, the change of {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}
       type (e.g. start/end of a bridge), etc.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.5.9.yaml
+++ b/concepts/concept-3.3.5.9.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: lane link
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.5.5,link}} that represents a {{urn:iso:std:iso:14812:3.3.1.13,lane}}
-      of a {{urn:iso:std:iso:14812:3.3.5.6,road link}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.5.5>>,link}} that represents a {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane}}
+      of a {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link}}"
   notes:
-  - content: A {{urn:iso:std:iso:14812:3.3.5.10,lane segment}} can start or end at
-      {{urn:iso:std:iso:14812:3.4.1.1,location,locations}} other than the start or
-      end of the corresponding {{urn:iso:std:iso:14812:3.3.5.8,road segment}} (e.g.
+  - content: A {{<<urn:iso:std:iso:14812:3.3.5.10>>,lane segment}} can start or end at
+      {{<<urn:iso:std:iso:14812:3.4.1.1>>,location,locations}} other than the start or
+      end of the corresponding {{<<urn:iso:std:iso:14812:3.3.5.8>>,road segment}} (e.g.
       a lane can start mid-block).
-  - content: A lane segment only includes the{{urn:iso:std:iso:14812:3.5.9.2,sequential}}
+  - content: A lane segment only includes the{{<<urn:iso:std:iso:14812:3.5.9.2>>,sequential}}
       lane links, it does not include lane links from adjacent lanes.
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.6.1.yaml
+++ b/concepts/concept-3.3.6.1.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: intersection
   definition:
-  - content: space where two or more {{urn:iso:std:iso:14812:3.3.5.1,road,roads}}
+  - content: space where two or more {{<<urn:iso:std:iso:14812:3.3.5.1>>,road,roads}}
       meet or cross
   notes:
-  - content: Intersections can be associated with zero {{urn:iso:std:iso:14812:3.3.6.2,junction,junctions}},
+  - content: Intersections can be associated with zero {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction,junctions}},
       such as a motorway crossing a road without any connecting ramps, or can be associated
-      with one or more junctions, such as a diamond {{urn:iso:std:iso:14812:3.3.6.9,interchange}}.
+      with one or more junctions, such as a diamond {{<<urn:iso:std:iso:14812:3.3.6.9>>,interchange}}.
   - content: Complex intersections can be viewed as multiple intersections by providing
-      separate designations for distinct {{urn:iso:std:iso:14812:3.3.5.6,road link,road
+      separate designations for distinct {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link,road
       links}}. For example, one model could depict a complex intersection as being
       associated with multiple junctions; another model could depict the same physical
       infrastructure as being multiple intersections that are interconnected by different

--- a/concepts/concept-3.3.6.10.yaml
+++ b/concepts/concept-3.3.6.10.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: grade separated manoeuvre
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.6.7,intersection manoeuvre,manoeuvre}} that
+  - content: "{{<<urn:iso:std:iso:14812:3.3.6.7>>,intersection manoeuvre,manoeuvre}} that
       is vertically separated from one or more manoeuvres that cross its two-dimensional
       path"
   notes: []

--- a/concepts/concept-3.3.6.2.yaml
+++ b/concepts/concept-3.3.6.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: junction
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.6.1,intersection}} that allows {{urn:iso:std:iso:14812:3.6.1.1,traveller,travellers}}
-      to change {{urn:iso:std:iso:14812:3.3.5.1,road,roads}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.6.1>>,intersection}} that allows {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller,travellers}}
+      to change {{<<urn:iso:std:iso:14812:3.3.5.1>>,road,roads}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.6.3.yaml
+++ b/concepts/concept-3.3.6.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ingress lane
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,traffic lane}} designed for entering
-      a {{urn:iso:std:iso:14812:3.3.6.2,junction}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}} designed for entering
+      a {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.6.4.yaml
+++ b/concepts/concept-3.3.6.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ingress link
   definition:
-  - content: all {{urn:iso:std:iso:14812:3.3.6.3,ingress lane,ingress lanes}} on a
-      {{urn:iso:std:iso:14812:3.3.5.6,road link}}
+  - content: all {{<<urn:iso:std:iso:14812:3.3.6.3>>,ingress lane,ingress lanes}} on a
+      {{<<urn:iso:std:iso:14812:3.3.5.6>>,road link}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.6.5.yaml
+++ b/concepts/concept-3.3.6.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: egress lane
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.1.13,traffic lane}} designed for exiting
-      a {{urn:iso:std:iso:14812:3.3.6.2,junction}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane}} designed for exiting
+      a {{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.3.6.6.yaml
+++ b/concepts/concept-3.3.6.6.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: egress link
   definition:
-  - content: all {{urn:iso:std:iso:14812:3.3.6.5,egress lane,egress lanes}} on a {{urn:iso:std:iso:14812:3.3.5.6,road
+  - content: all {{<<urn:iso:std:iso:14812:3.3.6.5>>,egress lane,egress lanes}} on a {{<<urn:iso:std:iso:14812:3.3.5.6>>,road
       link}}
   notes: []
   examples: []

--- a/concepts/concept-3.3.6.7.yaml
+++ b/concepts/concept-3.3.6.7.yaml
@@ -14,8 +14,8 @@ eng:
     designation: maneuver
   domain: junction
   definition:
-  - content: movement from an {{urn:iso:std:iso:14812:3.3.6.3,ingress lane}} to an
-      {{urn:iso:std:iso:14812:3.3.6.5,egress lane}}
+  - content: movement from an {{<<urn:iso:std:iso:14812:3.3.6.3>>,ingress lane}} to an
+      {{<<urn:iso:std:iso:14812:3.3.6.5>>,egress lane}}
   notes:
   - content: The term "maneuver" is the American English spelling.
   examples: []

--- a/concepts/concept-3.3.6.8.yaml
+++ b/concepts/concept-3.3.6.8.yaml
@@ -13,7 +13,7 @@ eng:
     normative_status: admitted
     designation: grade junction
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.6.2,junction}} without any {{urn:iso:std:iso:14812:3.3.6.10,grade
+  - content: "{{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}} without any {{<<urn:iso:std:iso:14812:3.3.6.10>>,grade
       separated manoeuvre,grade separated manoeuvres}}"
   notes: []
   examples: []

--- a/concepts/concept-3.3.6.9.yaml
+++ b/concepts/concept-3.3.6.9.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: interchange
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.3.6.2,junction}} with at least one {{urn:iso:std:iso:14812:3.3.6.10,grade
+  - content: "{{<<urn:iso:std:iso:14812:3.3.6.2>>,junction}} with at least one {{<<urn:iso:std:iso:14812:3.3.6.10>>,grade
       separated manoeuvre}}"
   notes:
   - content: The term "interchange" typically refers to the facilities that enable
-      all available manoeuvres at the grade separated {{urn:iso:std:iso:14812:3.3.6.1,intersection}},
+      all available manoeuvres at the grade separated {{<<urn:iso:std:iso:14812:3.3.6.1>>,intersection}},
       which typically includes multiple junctions.
-  - content: The grade separation allows {{urn:iso:std:iso:14812:3.6.1.1,traveller,travellers}}
-      on the {{urn:iso:std:iso:14812:3.3.5.5,link}} to pass unimpeded through the
+  - content: The grade separation allows {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller,travellers}}
+      on the {{<<urn:iso:std:iso:14812:3.3.5.5>>,link}} to pass unimpeded through the
       interchange when congestion is not present.
   examples: []
   language_code: eng

--- a/concepts/concept-3.4.1.2.yaml
+++ b/concepts/concept-3.4.1.2.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS spatial location
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.1.1,location}} within three-dimensional
+  - content: "{{<<urn:iso:std:iso:14812:3.4.1.1>>,location}} within three-dimensional
       space"
   notes:
   - content: The "location" could be a point (consuming no space) or could consume

--- a/concepts/concept-3.4.1.3.yaml
+++ b/concepts/concept-3.4.1.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: point location
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.1.2,spatial location}} with no length in
+  - content: "{{<<urn:iso:std:iso:14812:3.4.1.2>>,spatial location}} with no length in
       any of the spatial dimensions"
   notes: []
   examples: []

--- a/concepts/concept-3.4.1.5.yaml
+++ b/concepts/concept-3.4.1.5.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS linear location
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.1.2,spatial location}} that extends between
-      two {{urn:iso:std:iso:14812:3.4.1.3,point location,point locations}} along a
+  - content: "{{<<urn:iso:std:iso:14812:3.4.1.2>>,spatial location}} that extends between
+      two {{<<urn:iso:std:iso:14812:3.4.1.3>>,point location,point locations}} along a
       defined path"
   notes:
   - content: The path can exhibit 3-dimensional characteristics.

--- a/concepts/concept-3.4.1.6.yaml
+++ b/concepts/concept-3.4.1.6.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS area location
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.1.2,spatial location}} enclosed within a
+  - content: "{{<<urn:iso:std:iso:14812:3.4.1.2>>,spatial location}} enclosed within a
       two-dimensional boundary or boundaries across a defined surface"
   notes:
   - content: The boundary can consist of a single curvilinear line (e.g. a circle)

--- a/concepts/concept-3.4.2.1.yaml
+++ b/concepts/concept-3.4.2.1.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: ITS location referencing
   definition:
-  - content: process used to develop a {{urn:iso:std:iso:14812:3.4.2.2,spatial reference}}
+  - content: process used to develop a {{<<urn:iso:std:iso:14812:3.4.2.2>>,spatial reference}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.4.2.2.yaml
+++ b/concepts/concept-3.4.2.2.yaml
@@ -13,7 +13,7 @@ eng:
     normative_status: admitted
     designation: location reference
   definition:
-  - content: description of a {{urn:iso:std:iso:14812:3.4.1.2,spatial location}} in
+  - content: description of a {{<<urn:iso:std:iso:14812:3.4.1.2>>,spatial location}} in
       the real world according to a defined reference system
   notes:
   - content: It is not necessary for the rules be formal coordinates but they could

--- a/concepts/concept-3.4.2.3.yaml
+++ b/concepts/concept-3.4.2.3.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: admitted
     designation: dynamic location reference
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.2.2,spatial reference}} generated on-the-fly
+  - content: "{{<<urn:iso:std:iso:14812:3.4.2.2>>,spatial reference}} generated on-the-fly
       based on geographic properties in a digital map database"
   notes: []
   examples: []

--- a/concepts/concept-3.4.2.4.yaml
+++ b/concepts/concept-3.4.2.4.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: admitted
     designation: pre-coded location reference
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.2.2,spatial reference}} using a unique identifier
-      that is agreed upon in both the sender and receiver {{urn:iso:std:iso:14812:3.1.2.1,system}}
-      to select a {{urn:iso:std:iso:14812:3.4.1.1,location}} from a set of pre-coded
+  - content: "{{<<urn:iso:std:iso:14812:3.4.2.2>>,spatial reference}} using a unique identifier
+      that is agreed upon in both the sender and receiver {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}
+      to select a {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}} from a set of pre-coded
       locations"
   notes: []
   examples: []

--- a/concepts/concept-3.4.2.5.yaml
+++ b/concepts/concept-3.4.2.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: link location
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.2.4,pre-coded spatial reference}} defined
-      within the {{urn:iso:std:iso:14812:3.3.5.2,road network}} database"
+  - content: "{{<<urn:iso:std:iso:14812:3.4.2.4>>,pre-coded spatial reference}} defined
+      within the {{<<urn:iso:std:iso:14812:3.3.5.2>>,road network}} database"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.4.2.6.yaml
+++ b/concepts/concept-3.4.2.6.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: deprecated
     designation: location code
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.4.2.2,spatial reference}} in the form of a
-      label or code that identifies a {{urn:iso:std:iso:14812:3.4.1.1,location}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.4.2.2>>,spatial reference}} in the form of a
+      label or code that identifies a {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}}"
   notes:
   - content: The term "location code" has been used previously in ISO/TC 204 documents,
       but "geographic identifier" is preferred to better align with the activities

--- a/concepts/concept-3.4.2.7.yaml
+++ b/concepts/concept-3.4.2.7.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: admitted
     designation: location table
   definition:
-  - content: register of {{urn:iso:std:iso:14812:3.4.2.2,spatial reference,spatial
-      references}} of one or more {{urn:iso:std:iso:14812:3.4.1.1,location}} sub-types
+  - content: register of {{<<urn:iso:std:iso:14812:3.4.2.2>>,spatial reference,spatial
+      references}} of one or more {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}} sub-types
       containing some information regarding position
   notes:
   - content: The positional information need not be coordinates but could be descriptive.

--- a/concepts/concept-3.5.1.1.yaml
+++ b/concepts/concept-3.5.1.1.yaml
@@ -8,7 +8,7 @@ eng:
     designation: service
   definition:
   - content: provision of one or more capabilities, functionalities or facilities
-      to enable one or more tasks to fulfil a {{urn:iso:std:iso:14812:3.5.1.4,user
+      to enable one or more tasks to fulfil a {{<<urn:iso:std:iso:14812:3.5.1.4>>,user
       need,need}}
   notes: []
   examples: []

--- a/concepts/concept-3.5.1.2.yaml
+++ b/concepts/concept-3.5.1.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: service provider
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that delivers one or more {{urn:iso:std:iso:14812:3.5.2.1,service,services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that delivers one or more {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.1.3.yaml
+++ b/concepts/concept-3.5.1.3.yaml
@@ -10,11 +10,11 @@ eng:
     normative_status: preferred
     designation: consumer
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that has a {{urn:iso:std:iso:14812:3.5.1.4,user
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that has a {{<<urn:iso:std:iso:14812:3.5.1.4>>,user
       need,need}} to be fulfilled"
   notes:
   - content: The term "consumer" can be used when fulfilling the need results in the
-      consumption of a {{urn:iso:std:iso:14812:3.1.6.2,resource}}.
+      consumption of a {{<<urn:iso:std:iso:14812:3.1.6.2>>,resource}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.5.10.1.yaml
+++ b/concepts/concept-3.5.10.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: network model
   definition:
-  - content: infrastructure framework for the agreement between a {{urn:iso:std:iso:14812:3.5.1.2,service
-      provider}} and a {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: infrastructure framework for the agreement between a {{<<urn:iso:std:iso:14812:3.5.1.2>>,service
+      provider}} and a {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.10.2.yaml
+++ b/concepts/concept-3.5.10.2.yaml
@@ -8,9 +8,9 @@ eng:
     designation: station-based roundtrip
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.1,operational model,operational mode}}
-      where the {{urn:iso:std:iso:14812:3.5.2.1,transport service}} is initiated and
-      terminated at the same facility managed by the {{urn:iso:std:iso:14812:3.5.2.2,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.1>>,operational model,operational mode}}
+      where the {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} is initiated and
+      terminated at the same facility managed by the {{<<urn:iso:std:iso:14812:3.5.2.2>>,transport
       provider}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.10.3.yaml
+++ b/concepts/concept-3.5.10.3.yaml
@@ -8,9 +8,9 @@ eng:
     designation: station-based one-way
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.1,operational model,operational mode}}
-      where the {{urn:iso:std:iso:14812:3.5.2.1,transport service}} is initiated and
-      terminated at two different facilities managed by the {{urn:iso:std:iso:14812:3.5.2.2,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.1>>,operational model,operational mode}}
+      where the {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} is initiated and
+      terminated at two different facilities managed by the {{<<urn:iso:std:iso:14812:3.5.2.2>>,transport
       provider}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.10.4.yaml
+++ b/concepts/concept-3.5.10.4.yaml
@@ -8,8 +8,8 @@ eng:
     designation: free-floating
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.10.1,network model}} where the {{urn:iso:std:iso:14812:3.5.2.1,transport
-      service}} may be initiated and terminated at any {{urn:iso:std:iso:14812:3.4.1.1,location}}
+  - content: "{{<<urn:iso:std:iso:14812:3.5.10.1>>,network model}} where the {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport
+      service}} may be initiated and terminated at any {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}}
       meeting basic criteria"
   notes:
   - content: The basic criteria typically include geographic limits and requirements

--- a/concepts/concept-3.5.11.1.yaml
+++ b/concepts/concept-3.5.11.1.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: shuttle service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.6.2,shared transport service}} that transports
-      {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}} between two specified
-      {{urn:iso:std:iso:14812:3.4.1.1,location,locations}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.6.2>>,shared transport service}} that transports
+      {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}} between two specified
+      {{<<urn:iso:std:iso:14812:3.4.1.1>>,location,locations}}"
   notes:
-  - content: Each location can be defined as point, linear or {{urn:iso:std:iso:14812:3.4.1.6,area
+  - content: Each location can be defined as point, linear or {{<<urn:iso:std:iso:14812:3.4.1.6>>,area
       location,area locations}}. However, the areas of the two locations should not
       overlap.
   examples: []

--- a/concepts/concept-3.5.11.2.yaml
+++ b/concepts/concept-3.5.11.2.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: taxi service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.2,commercial}} {{urn:iso:std:iso:14812:3.5.6.2,shared
-      transport service}} that transports {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}
-      {{urn:iso:std:iso:14812:3.5.9.2,sequential,sequentially}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}} {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared
+      transport service}} that transports {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}
+      {{<<urn:iso:std:iso:14812:3.5.9.2>>,sequential,sequentially}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.11.3.yaml
+++ b/concepts/concept-3.5.11.3.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: taxi-share service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.2,commercial}} {{urn:iso:std:iso:14812:3.5.6.2,shared
-      transport service}} that transports {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}
-      {{urn:iso:std:iso:14812:3.5.9.3,concurrent,concurrently}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}} {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared
+      transport service}} that transports {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}
+      {{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent,concurrently}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.11.4.yaml
+++ b/concepts/concept-3.5.11.4.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: rideshare service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.4,cooperative}} {{urn:iso:std:iso:14812:3.5.6.2,shared
-      transport service}} that transports {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}
-      {{urn:iso:std:iso:14812:3.5.9.3,concurrent,concurrently}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.4>>,cooperative}} {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared
+      transport service}} that transports {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}
+      {{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent,concurrently}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.11.5.yaml
+++ b/concepts/concept-3.5.11.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ridesourced service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.2,commercial}}, {{urn:iso:std:iso:14812:3.5.7.5,peer-to-peer}}
-      {{urn:iso:std:iso:14812:3.5.6.2,shared transport service}} that transports {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}}, {{<<urn:iso:std:iso:14812:3.5.7.5>>,peer-to-peer}}
+      {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared transport service}} that transports {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.11.6.yaml
+++ b/concepts/concept-3.5.11.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ridesplit service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.11.5,ridesourced service}} that serves {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}
-      {{urn:iso:std:iso:14812:3.5.9.3,concurrent,concurrently}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.11.5>>,ridesourced service}} that serves {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}
+      {{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent,concurrently}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.11.7.yaml
+++ b/concepts/concept-3.5.11.7.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: courier network service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.2,commercial}}, {{urn:iso:std:iso:14812:3.5.7.5,peer-to-peer}}
-      {{urn:iso:std:iso:14812:3.5.6.2,shared transport service}} that transports goods"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}}, {{<<urn:iso:std:iso:14812:3.5.7.5>>,peer-to-peer}}
+      {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared transport service}} that transports goods"
   notes:
   - content: The goods are typically small packages, letters, food, etc.
   examples: []

--- a/concepts/concept-3.5.12.1.yaml
+++ b/concepts/concept-3.5.12.1.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: admitted
     designation: bicycle sharing service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.6.3,shared vehicle service}} that shares
+  - content: "{{<<urn:iso:std:iso:14812:3.5.6.3>>,shared vehicle service}} that shares
       bicycles"
   notes:
   - content: The term "bicycle sharing service" is admitted, but "bikesharing service"

--- a/concepts/concept-3.5.12.2.yaml
+++ b/concepts/concept-3.5.12.2.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: admitted
     designation: passenger car sharing service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.6.3,shared vehicle service}} that shares
-      {{urn:iso:std:iso:14812:3.6.2.1,passenger}} cars"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.6.3>>,shared vehicle service}} that shares
+      {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger}} cars"
   notes:
   - content: The term "passenger car sharing service" is admitted but has the same
       meaning.

--- a/concepts/concept-3.5.13.1.yaml
+++ b/concepts/concept-3.5.13.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: mobility app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.9.4,ITS-S application implementation}} designed
+  - content: "{{<<urn:iso:std:iso:14812:3.2.9.4>>,ITS-S application implementation}} designed
       to assist an individual transport consumer in understanding transport-related
       information, making decisions, and/or acting upon decisions"
   notes: []

--- a/concepts/concept-3.5.13.2.yaml
+++ b/concepts/concept-3.5.13.2.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: B2C mobility sharing app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
-      user}} in acquiring a {{urn:iso:std:iso:14812:3.5.2.1,transport service}} from
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
+      user}} in acquiring a {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} from
       a specific business"
   notes: []
   examples: []

--- a/concepts/concept-3.5.13.3.yaml
+++ b/concepts/concept-3.5.13.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: navigation app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
       user}} to determine the best route to a destination"
   notes: []
   examples: []

--- a/concepts/concept-3.5.13.4.yaml
+++ b/concepts/concept-3.5.13.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: P2P mobility sharing app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
-      user}} in acquiring {{urn:iso:std:iso:14812:3.5.2.1,transport service}} from
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
+      user}} in acquiring {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} from
       an individual that participates in the mobility app's network"
   notes: []
   examples: []

--- a/concepts/concept-3.5.13.5.yaml
+++ b/concepts/concept-3.5.13.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ridesourcing app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.4,P2P mobility sharing app}} for acquiring
-      a {{urn:iso:std:iso:14812:3.5.11.5,ridesourced service}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.4>>,P2P mobility sharing app}} for acquiring
+      a {{<<urn:iso:std:iso:14812:3.5.11.5>>,ridesourced service}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.13.6.yaml
+++ b/concepts/concept-3.5.13.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: public transport app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
-      user}} in using a {{urn:iso:std:iso:14812:3.5.6.1,public transport}} {{urn:iso:std:iso:14812:3.1.2.1,system}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
+      user}} in using a {{<<urn:iso:std:iso:14812:3.5.6.1>>,public transport}} {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}}"
   notes:
   - content: A public transport app can include features such as viewing maps, searching
       routes and schedules, real-time arrival information, ticketing, electronic boarding

--- a/concepts/concept-3.5.13.7.yaml
+++ b/concepts/concept-3.5.13.7.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: real-time traveller information app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that provides information
-      about current travel conditions to a {{urn:iso:std:iso:14812:3.5.2.3,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that provides information
+      about current travel conditions to a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
       user}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.13.8.yaml
+++ b/concepts/concept-3.5.13.8.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: taxi hailing app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
       user}} in electronically requesting a taxi"
   notes: []
   examples: []

--- a/concepts/concept-3.5.13.9.yaml
+++ b/concepts/concept-3.5.13.9.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: trip aggregator app
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.13.1,mobility app}} that assists a {{urn:iso:std:iso:14812:3.5.2.3,transport
-      user}} in planning trips that may span multiple vehicle modes or {{urn:iso:std:iso:14812:3.5.2.2,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.13.1>>,mobility app}} that assists a {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport
+      user}} in planning trips that may span multiple vehicle modes or {{<<urn:iso:std:iso:14812:3.5.2.2>>,transport
       provider,transport providers}}"
   notes:
-  - content: The assistance can include reservations, ticketing and similar {{urn:iso:std:iso:14812:3.5.2.1,service,services}}.
+  - content: The assistance can include reservations, ticketing and similar {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.5.2.1.yaml
+++ b/concepts/concept-3.5.2.1.yaml
@@ -11,9 +11,9 @@ eng:
     designation: service
   domain: transport
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.2.1,service}} that delivers one or more
-      {{urn:iso:std:iso:14812:3.1.1.3,material entity,material entities}} from one
-      {{urn:iso:std:iso:14812:3.4.1.1,location}} to another to satisfy a {{urn:iso:std:iso:14812:3.5.2.4,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.2.1>>,service}} that delivers one or more
+      {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity,material entities}} from one
+      {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}} to another to satisfy a {{<<urn:iso:std:iso:14812:3.5.2.4>>,transport
       need}}"
   notes:
   - content: The material entities delivered can be people and/or goods.

--- a/concepts/concept-3.5.2.2.yaml
+++ b/concepts/concept-3.5.2.2.yaml
@@ -14,7 +14,7 @@ eng:
     designation: provider
   domain: transport
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that delivers one or more {{urn:iso:std:iso:14812:3.5.2.1,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that delivers one or more {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport
       service,transport services}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.2.3.yaml
+++ b/concepts/concept-3.5.2.3.yaml
@@ -14,7 +14,7 @@ eng:
     designation: consumer
   domain: transport
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that has a {{urn:iso:std:iso:14812:3.5.2.4,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that has a {{<<urn:iso:std:iso:14812:3.5.2.4>>,transport
       need}} to be fulfilled"
   notes: []
   examples: []

--- a/concepts/concept-3.5.2.4.yaml
+++ b/concepts/concept-3.5.2.4.yaml
@@ -14,9 +14,9 @@ eng:
     designation: need
   domain: transport
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.1.4,user need,need}} to transport one or
-      more {{urn:iso:std:iso:14812:3.1.1.3,material entity,material entities}} to
-      a different {{urn:iso:std:iso:14812:3.4.1.1,location}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.1.4>>,user need,need}} to transport one or
+      more {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity,material entities}} to
+      a different {{<<urn:iso:std:iso:14812:3.4.1.1>>,location}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.3.1.yaml
+++ b/concepts/concept-3.5.3.1.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: service
   definition:
-  - content: functionality that fulfils one or more {{urn:iso:std:iso:14812:3.5.3.4,ITS
+  - content: functionality that fulfils one or more {{<<urn:iso:std:iso:14812:3.5.3.4>>,ITS
       user need}}
   notes: []
   examples: []

--- a/concepts/concept-3.5.3.2.yaml
+++ b/concepts/concept-3.5.3.2.yaml
@@ -10,12 +10,12 @@ eng:
     normative_status: preferred
     designation: service provider
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that delivers one or more {{urn:iso:std:iso:14812:3.5.3.1,ITS
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that delivers one or more {{<<urn:iso:std:iso:14812:3.5.3.1>>,ITS
       service}}"
   notes:
-  - content: "{{urn:iso:std:iso:14812:3.1.2.5,cooperative ITS,Cooperative ITS}} services
+  - content: "{{<<urn:iso:std:iso:14812:3.1.2.5>>,cooperative ITS,Cooperative ITS}} services
       often require multiple entities cooperatively working together to provide a
-      unified {{urn:iso:std:iso:14812:3.5.2.1,service}} where the individual entities
+      unified {{<<urn:iso:std:iso:14812:3.5.2.1>>,service}} where the individual entities
       are simultaneously ITS service providers and ITS users."
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.3.3.yaml
+++ b/concepts/concept-3.5.3.3.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: preferred
     designation: user
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that has an {{urn:iso:std:iso:14812:3.5.3.4,ITS
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that has an {{<<urn:iso:std:iso:14812:3.5.3.4>>,ITS
       user need}} to be fulfilled"
   notes: []
   examples: []

--- a/concepts/concept-3.5.3.4.yaml
+++ b/concepts/concept-3.5.3.4.yaml
@@ -13,9 +13,9 @@ eng:
     normative_status: preferred
     designation: need
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.1.4,user need,need}} of an {{urn:iso:std:iso:14812:3.1.1.1,entity}}
-      external to the {{urn:iso:std:iso:14812:3.1.2.4,intelligent transport system}}
-      for a {{urn:iso:std:iso:14812:3.1.2.3,surface transport system}} benefit that
+  - content: "{{<<urn:iso:std:iso:14812:3.5.1.4>>,user need,need}} of an {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}
+      external to the {{<<urn:iso:std:iso:14812:3.1.2.4>>,intelligent transport system}}
+      for a {{<<urn:iso:std:iso:14812:3.1.2.3>>,surface transport system}} benefit that
       can be met with the use of information, communication, sensor, and/or control
       technologies"
   notes: []

--- a/concepts/concept-3.5.4.1.yaml
+++ b/concepts/concept-3.5.4.1.yaml
@@ -11,8 +11,8 @@ eng:
     designation: service
   domain: ITS-S
   definition:
-  - content: performance of one or more tasks to fulfil an {{urn:iso:std:iso:14812:3.5.4.4,ITS-S
-      user need}} for an {{urn:iso:std:iso:14812:3.5.4.3,ITS-S user}}
+  - content: performance of one or more tasks to fulfil an {{<<urn:iso:std:iso:14812:3.5.4.4>>,ITS-S
+      user need}} for an {{<<urn:iso:std:iso:14812:3.5.4.3>>,ITS-S user}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.4.2.yaml
+++ b/concepts/concept-3.5.4.2.yaml
@@ -11,8 +11,8 @@ eng:
     designation: service provider
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS-S}} that delivers one
-      or more {{urn:iso:std:iso:14812:3.5.4.1,ITS-S service,ITS-S services}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS-S}} that delivers one
+      or more {{<<urn:iso:std:iso:14812:3.5.4.1>>,ITS-S service,ITS-S services}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.4.3.yaml
+++ b/concepts/concept-3.5.4.3.yaml
@@ -11,7 +11,7 @@ eng:
     designation: user
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that has an {{urn:iso:std:iso:14812:3.5.4.4,ITS-S
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that has an {{<<urn:iso:std:iso:14812:3.5.4.4>>,ITS-S
       user need}} to be fulfilled"
   notes: []
   examples: []

--- a/concepts/concept-3.5.4.4.yaml
+++ b/concepts/concept-3.5.4.4.yaml
@@ -14,8 +14,8 @@ eng:
     designation: need
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.1.4,user need,need}} for processing within
-      a {{urn:iso:std:iso:14812:3.2.7.1,bounded secured managed domain,bounded, secure,
+  - content: "{{<<urn:iso:std:iso:14812:3.5.1.4>>,user need,need}} for processing within
+      a {{<<urn:iso:std:iso:14812:3.2.7.1>>,bounded secured managed domain,bounded, secure,
       managed domain}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.5.1.yaml
+++ b/concepts/concept-3.5.5.1.yaml
@@ -11,7 +11,7 @@ eng:
     designation: communication process
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that delivers one or more {{urn:iso:std:iso:14812:3.5.5.2,ITS-S
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that delivers one or more {{<<urn:iso:std:iso:14812:3.5.5.2>>,ITS-S
       communications service,ITS-S communication services}}"
   notes: []
   examples: []

--- a/concepts/concept-3.5.5.2.yaml
+++ b/concepts/concept-3.5.5.2.yaml
@@ -11,8 +11,8 @@ eng:
     designation: communication service
   domain: ITS-S
   definition:
-  - content: performance of one or more tasks to fulfil an {{urn:iso:std:iso:14812:3.5.5.4,ITS-S
-      communications need,ITS-S communication need}} for an {{urn:iso:std:iso:14812:3.5.5.3,ITS-S
+  - content: performance of one or more tasks to fulfil an {{<<urn:iso:std:iso:14812:3.5.5.4>>,ITS-S
+      communications need,ITS-S communication need}} for an {{<<urn:iso:std:iso:14812:3.5.5.3>>,ITS-S
       communications user,ITS-S communication user}}
   notes: []
   examples: []

--- a/concepts/concept-3.5.5.3.yaml
+++ b/concepts/concept-3.5.5.3.yaml
@@ -11,7 +11,7 @@ eng:
     designation: communication user
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.1,entity}} that has an {{urn:iso:std:iso:14812:3.5.5.4,ITS-S
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}} that has an {{<<urn:iso:std:iso:14812:3.5.5.4>>,ITS-S
       communications need,ITS-S communication need}} to be fulfilled"
   notes: []
   examples: []

--- a/concepts/concept-3.5.5.4.yaml
+++ b/concepts/concept-3.5.5.4.yaml
@@ -11,9 +11,9 @@ eng:
     designation: communication need
   domain: ITS-S
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.1.4,user need,need}} for communication functionality
-      that connects an {{urn:iso:std:iso:14812:3.2.7.3,ITS station,ITS-S}} to other
-      {{urn:iso:std:iso:14812:3.3.5.4,node,nodes}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.1.4>>,user need,need}} for communication functionality
+      that connects an {{<<urn:iso:std:iso:14812:3.2.7.3>>,ITS station,ITS-S}} to other
+      {{<<urn:iso:std:iso:14812:3.3.5.4>>,node,nodes}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.6.1.yaml
+++ b/concepts/concept-3.5.6.1.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: public transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.2.1,transport service}} that is publicly
-      accessible enabling the movement of one or more {{urn:iso:std:iso:14812:3.1.1.6,person,persons}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} that is publicly
+      accessible enabling the movement of one or more {{<<urn:iso:std:iso:14812:3.1.1.6>>,person,persons}}"
   notes:
   - content: A public transport service can be scheduled or on-demand.
   - content: A public transport service is based on the use of publicly accessible

--- a/concepts/concept-3.5.6.2.yaml
+++ b/concepts/concept-3.5.6.2.yaml
@@ -7,16 +7,16 @@ eng:
     normative_status: preferred
     designation: shared transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.2.1,transport service}} that relies upon
-      the same {{urn:iso:std:iso:14812:3.1.6.2,resource,resources}} to fulfil the
-      {{urn:iso:std:iso:14812:3.5.2.4,transport need,transport needs}} of multiple
-      unrelated {{urn:iso:std:iso:14812:3.5.2.3,transport user,transport users}} and
-      where the {{urn:iso:std:iso:14812:3.5.2.2,transport provider}} has the primary
+  - content: "{{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} that relies upon
+      the same {{<<urn:iso:std:iso:14812:3.1.6.2>>,resource,resources}} to fulfil the
+      {{<<urn:iso:std:iso:14812:3.5.2.4>>,transport need,transport needs}} of multiple
+      unrelated {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport user,transport users}} and
+      where the {{<<urn:iso:std:iso:14812:3.5.2.2>>,transport provider}} has the primary
       responsibility for the operation of the transport mode"
   notes:
   - content: A shared transport service might not be dependent upon a vehicle and/or
       could be multi-modal. For example, a letter courier service could rely on walking
-      and {{urn:iso:std:iso:14812:3.5.6.1,public transport}}.
+      and {{<<urn:iso:std:iso:14812:3.5.6.1>>,public transport}}.
   - content: Responsibilities of the transport service can be further delegated to
       others. For example, a courier service relying on public transport would delegate
       the operation of the transport mode to the public transport operator.

--- a/concepts/concept-3.5.6.3.yaml
+++ b/concepts/concept-3.5.6.3.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: shared vehicle service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.2.1,transport service}} that {{urn:iso:std:iso:14812:3.5.9.2,sequential,sequentially}}
-      provides the same {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicles}} to multiple
-      unrelated {{urn:iso:std:iso:14812:3.5.2.3,transport user,transport users}} and
+  - content: "{{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} that {{<<urn:iso:std:iso:14812:3.5.9.2>>,sequential,sequentially}}
+      provides the same {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicles}} to multiple
+      unrelated {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport user,transport users}} and
       where the transport user has the primary responsibility for the operation of
       the vehicle"
   notes:

--- a/concepts/concept-3.5.6.4.yaml
+++ b/concepts/concept-3.5.6.4.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: transport sharing
   definition:
-  - content: using a {{urn:iso:std:iso:14812:3.5.6.2,shared transport service}}
+  - content: using a {{<<urn:iso:std:iso:14812:3.5.6.2>>,shared transport service}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.6.5.yaml
+++ b/concepts/concept-3.5.6.5.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: vehicle sharing
   definition:
-  - content: using a {{urn:iso:std:iso:14812:3.5.6.3,shared vehicle service}}
+  - content: using a {{<<urn:iso:std:iso:14812:3.5.6.3>>,shared vehicle service}}
   notes:
   - content: This term can be specialized by replacing "vehicle" with any defined
       vehicle type. However, in some cases the preferred form is to consolidate terms

--- a/concepts/concept-3.5.7.1.yaml
+++ b/concepts/concept-3.5.7.1.yaml
@@ -10,11 +10,11 @@ eng:
     normative_status: preferred
     designation: shared mobility contract model
   definition:
-  - content: legal framework for the agreement between a {{urn:iso:std:iso:14812:3.5.1.2,service
-      provider}} and a {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: legal framework for the agreement between a {{<<urn:iso:std:iso:14812:3.5.1.2>>,service
+      provider}} and a {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
   notes:
   - content: Contracts can be via a third party, implied or verbal, especially in
-      the case of {{urn:iso:std:iso:14812:3.5.7.5,peer-to-peer}}.
+      the case of {{<<urn:iso:std:iso:14812:3.5.7.5>>,peer-to-peer}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.5.7.2.yaml
+++ b/concepts/concept-3.5.7.2.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: corporate customer model
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.7.1,contractual model}} where the {{urn:iso:std:iso:14812:3.5.3.4,user}}
-      is a {{urn:iso:std:iso:14812:3.5.8.2,commercial}} {{urn:iso:std:iso:14812:3.1.1.1,entity}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.7.1>>,contractual model}} where the {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
+      is a {{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}} {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}"
   notes: []
   examples:
-  - content: A business purchasing monthly {{urn:iso:std:iso:14812:3.5.6.1,public
+  - content: A business purchasing monthly {{<<urn:iso:std:iso:14812:3.5.6.1>>,public
       transport}} passes for its employees.
   - content: A commercial entity using a commercial courier service for package delivery.
   language_code: eng

--- a/concepts/concept-3.5.7.3.yaml
+++ b/concepts/concept-3.5.7.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: private customer model
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.7.1,contractual model}} where the {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: "{{<<urn:iso:std:iso:14812:3.5.7.1>>,contractual model}} where the {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
       is an individual"
   notes: []
   examples: []

--- a/concepts/concept-3.5.7.4.yaml
+++ b/concepts/concept-3.5.7.4.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: government customer model
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.7.1,contractual model}} where the {{urn:iso:std:iso:14812:3.5.3.4,user}}
-      is a governmental {{urn:iso:std:iso:14812:3.1.1.1,entity}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.7.1>>,contractual model}} where the {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
+      is a governmental {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}"
   notes: []
   examples:
-  - content: A governmental entity using a {{urn:iso:std:iso:14812:3.5.8.2,commercial}}
+  - content: A governmental entity using a {{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}}
       courier service for package delivery.
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.5.7.5.yaml
+++ b/concepts/concept-3.5.7.5.yaml
@@ -8,11 +8,11 @@ eng:
     designation: peer-to-peer
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.7.3,private customer model}} where the {{urn:iso:std:iso:14812:3.5.1.2,service
+  - content: "{{<<urn:iso:std:iso:14812:3.5.7.3>>,private customer model}} where the {{<<urn:iso:std:iso:14812:3.5.1.2>>,service
       provider}} is an individual"
   notes:
   - content: The customer and provider can connect and/or contract through a third-party
-      {{urn:iso:std:iso:14812:3.5.2.1,service}}.
+      {{<<urn:iso:std:iso:14812:3.5.2.1>>,service}}.
   examples:
   - content: Ridesourcing.
   language_code: eng

--- a/concepts/concept-3.5.8.1.yaml
+++ b/concepts/concept-3.5.8.1.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: financial model
   definition:
-  - content: economic framework for the agreement between a {{urn:iso:std:iso:14812:3.5.1.2,service
-      provider}} and a {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: economic framework for the agreement between a {{<<urn:iso:std:iso:14812:3.5.1.2>>,service
+      provider}} and a {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.8.2.yaml
+++ b/concepts/concept-3.5.8.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: commercial
   definition:
-  - content: type of{{urn:iso:std:iso:14812:3.5.8.1,financial model}} where {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: type of{{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}} where {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
       are provided with a profit motive
   notes: []
   examples: []

--- a/concepts/concept-3.5.8.3.yaml
+++ b/concepts/concept-3.5.8.3.yaml
@@ -7,17 +7,17 @@ eng:
     normative_status: preferred
     designation: public
   definition:
-  - content: type of{{urn:iso:std:iso:14812:3.5.8.1,financial model}} where {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: type of{{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}} where {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
       are provided by an administrative authority in an attempt to better serve societal
       interests
   notes:
-  - content: The {{urn:iso:std:iso:14812:3.5.2.1,transport service}} is typically
+  - content: The {{<<urn:iso:std:iso:14812:3.5.2.1>>,transport service}} is typically
       offered to the transport consumer for less than the full capital and operating
       cost of providing the service, but this is not a requirement.
   - content: Typically, the administrative authority is a local government agency;
       but it could be another administrative authority, such as the national government
-      or a {{urn:iso:std:iso:14812:3.5.8.2,commercial}} {{urn:iso:std:iso:14812:3.1.1.1,entity}}
-      managing {{urn:iso:std:iso:14812:3.5.2.4,transport need,transport needs}} on
+      or a {{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}} {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}
+      managing {{<<urn:iso:std:iso:14812:3.5.2.4>>,transport need,transport needs}} on
       their campus.
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.8.4.yaml
+++ b/concepts/concept-3.5.8.4.yaml
@@ -7,11 +7,11 @@ eng:
     normative_status: preferred
     designation: cooperative
   definition:
-  - content: type of{{urn:iso:std:iso:14812:3.5.8.1,financial model}} where {{urn:iso:std:iso:14812:3.5.3.4,user,users}}
-      partner to defray the costs of {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: type of{{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}} where {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}}
+      partner to defray the costs of {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
   notes:
-  - content: Cooperative models are exclusive {{urn:iso:std:iso:14812:3.5.8.2,commercial}}
-      and {{urn:iso:std:iso:14812:3.5.8.3,public}} models.
+  - content: Cooperative models are exclusive {{<<urn:iso:std:iso:14812:3.5.8.2>>,commercial}}
+      and {{<<urn:iso:std:iso:14812:3.5.8.3>>,public}} models.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.5.8.5.yaml
+++ b/concepts/concept-3.5.8.5.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: mutual benefit
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.4,cooperative}} {{urn:iso:std:iso:14812:3.5.8.1,financial
-      model}} where {{urn:iso:std:iso:14812:3.5.3.4,user,users}} partner on a per-use
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.4>>,cooperative}} {{<<urn:iso:std:iso:14812:3.5.8.1>>,financial
+      model}} where {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}} partner on a per-use
       basis"
   notes: []
   examples: []

--- a/concepts/concept-3.5.8.6.yaml
+++ b/concepts/concept-3.5.8.6.yaml
@@ -8,9 +8,9 @@ eng:
     designation: fractional ownership
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.4,cooperative}} {{urn:iso:std:iso:14812:3.5.8.1,financial
-      model}} where {{urn:iso:std:iso:14812:3.5.3.4,user,users}} partner to support
-      the purchase, maintenance and overhead costs associated with a {{urn:iso:std:iso:14812:3.5.2.1,service}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.4>>,cooperative}} {{<<urn:iso:std:iso:14812:3.5.8.1>>,financial
+      model}} where {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}} partner to support
+      the purchase, maintenance and overhead costs associated with a {{<<urn:iso:std:iso:14812:3.5.2.1>>,service}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.8.7.yaml
+++ b/concepts/concept-3.5.8.7.yaml
@@ -8,7 +8,7 @@ eng:
     designation: private
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.8.1,financial model}} where {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: "{{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}} where {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
       are provided to members of the owning organization without usage fees"
   notes: []
   examples:

--- a/concepts/concept-3.5.8.8.yaml
+++ b/concepts/concept-3.5.8.8.yaml
@@ -7,15 +7,15 @@ eng:
     normative_status: preferred
     designation: membership-based
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.5.8.1,financial model}}
-      that requires {{urn:iso:std:iso:14812:3.5.3.4,user,users}} to enter into an
-      agreement prior to receiving {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}}
+      that requires {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}} to enter into an
+      agreement prior to receiving {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
   notes:
   - content: The agreement can be associated with fees.
   - content: The agreement can be minimal, such as collecting user information for
       business purposes.
   - content: The membership can be granted as a part of a broader agreement. For example,
-      a university bus {{urn:iso:std:iso:14812:3.1.2.1,system}} can restrict access
+      a university bus {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} can restrict access
       to students and faculty.
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.8.9.yaml
+++ b/concepts/concept-3.5.8.9.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: open-access
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.5.8.1,financial model}}
-      that does not require membership within an organization to receive {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.5.8.1>>,financial model}}
+      that does not require membership within an organization to receive {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
   notes:
   - content: This includes models where membership is optional and can provide extra
       benefits.

--- a/concepts/concept-3.5.9.1.yaml
+++ b/concepts/concept-3.5.9.1.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: operational model
   definition:
-  - content: logistical framework for the agreement between a {{urn:iso:std:iso:14812:3.5.1.2,service
-      provider}} and a {{urn:iso:std:iso:14812:3.5.3.4,user}}
+  - content: logistical framework for the agreement between a {{<<urn:iso:std:iso:14812:3.5.1.2>>,service
+      provider}} and a {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}}
   notes:
-  - content: The logistical framework can set restrictions on how a {{urn:iso:std:iso:14812:3.6.2.1,passenger}}
+  - content: The logistical framework can set restrictions on how a {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger}}
       and/or good is received, transported and/or delivered.
   examples: []
   language_code: eng

--- a/concepts/concept-3.5.9.2.yaml
+++ b/concepts/concept-3.5.9.2.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: sequential
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.1,operational model}} where {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
-      are provided to a single {{urn:iso:std:iso:14812:3.5.3.4,user}} at any one time"
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.1>>,operational model}} where {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
+      are provided to a single {{<<urn:iso:std:iso:14812:3.5.3.4>>,user}} at any one time"
   notes:
-  - content: A single transport consumer can request the transport of multiple {{urn:iso:std:iso:14812:3.6.2.1,passenger,passengers}}.
+  - content: A single transport consumer can request the transport of multiple {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger,passengers}}.
   examples:
   - content: Traditional taxi service.
   language_code: eng

--- a/concepts/concept-3.5.9.3.yaml
+++ b/concepts/concept-3.5.9.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: concurrent
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.1,operational model}} where {{urn:iso:std:iso:14812:3.5.2.1,service,services}}
-      can be provided to multiple {{urn:iso:std:iso:14812:3.5.3.4,user,users}} at
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.1>>,operational model}} where {{<<urn:iso:std:iso:14812:3.5.2.1>>,service,services}}
+      can be provided to multiple {{<<urn:iso:std:iso:14812:3.5.3.4>>,user,users}} at
       any one time"
   notes: []
   examples: []

--- a/concepts/concept-3.5.9.4.yaml
+++ b/concepts/concept-3.5.9.4.yaml
@@ -8,7 +8,7 @@ eng:
     designation: fixed route
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.3,concurrent}} operation where transported
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent}} operation where transported
       items can only be received or delivered at stopping points contained in a pre-defined
       sequence"
   notes: []

--- a/concepts/concept-3.5.9.5.yaml
+++ b/concepts/concept-3.5.9.5.yaml
@@ -8,9 +8,9 @@ eng:
     designation: dynamic route
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.3,concurrent}} operation where transported
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent}} operation where transported
       items can only be received or delivered at stopping points within a pre-defined
-      {{urn:iso:std:iso:14812:3.5.2.1,service}} corridor"
+      {{<<urn:iso:std:iso:14812:3.5.2.1>>,service}} corridor"
   notes:
   - content: The service corridor is defined by the provider, who may impose further
       restrictions on where stops are allowed.

--- a/concepts/concept-3.5.9.6.yaml
+++ b/concepts/concept-3.5.9.6.yaml
@@ -8,9 +8,9 @@ eng:
     designation: paired on-demand
   domain: transport service
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.5.9.3,concurrent}} operation where the {{urn:iso:std:iso:14812:3.5.2.2,transport
+  - content: "{{<<urn:iso:std:iso:14812:3.5.9.3>>,concurrent}} operation where the {{<<urn:iso:std:iso:14812:3.5.2.2>>,transport
       provider}} may choose to divert from its path to service a new request from
-      another {{urn:iso:std:iso:14812:3.5.2.3,transport user,transport users}} while
+      another {{<<urn:iso:std:iso:14812:3.5.2.3>>,transport user,transport users}} while
       servicing an earlier transport user"
   notes: []
   examples:

--- a/concepts/concept-3.6.1.1.yaml
+++ b/concepts/concept-3.6.1.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: traveller
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} who is headed to a destination"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} who is headed to a destination"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.6.1.2.yaml
+++ b/concepts/concept-3.6.1.2.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: road user
   definition:
-  - content: mobile {{urn:iso:std:iso:14812:3.1.1.3,material entity}} within the {{urn:iso:std:iso:14812:3.3.1.2,road
+  - content: mobile {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} within the {{<<urn:iso:std:iso:14812:3.3.1.2>>,road
       reservation}}
   notes: []
   examples:
-  - content: "{{urn:iso:std:iso:14812:3.6.1.3,pedestrian,Pedestrians}}, road work
-      personnel, {{urn:iso:std:iso:14812:3.6.2.2,vehicle occupant,vehicle occupants}},
+  - content: "{{<<urn:iso:std:iso:14812:3.6.1.3>>,pedestrian,Pedestrians}}, road work
+      personnel, {{<<urn:iso:std:iso:14812:3.6.2.2>>,vehicle occupant,vehicle occupants}},
       occupied and unoccupied vehicles, horses, etc."
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.6.1.3.yaml
+++ b/concepts/concept-3.6.1.3.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: pedestrian
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} who is travelling on foot"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} who is travelling on foot"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.6.2.1.yaml
+++ b/concepts/concept-3.6.2.1.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: passenger
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} who has a reservation to travel
-      or is travelling in a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} except for any
-      crew, staff or {{urn:iso:std:iso:14812:3.6.2.3,driver,drivers}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} who has a reservation to travel
+      or is travelling in a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} except for any
+      crew, staff or {{<<urn:iso:std:iso:14812:3.6.2.3>>,driver,drivers}}"
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.6.2.2.yaml
+++ b/concepts/concept-3.6.2.2.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: vehicle occupant
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} in or on a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} in or on a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}"
   notes:
-  - content: A vehicle occupant in a stationary vehicle is not necessarily a {{urn:iso:std:iso:14812:3.6.1.1,traveller}}.
+  - content: A vehicle occupant in a stationary vehicle is not necessarily a {{<<urn:iso:std:iso:14812:3.6.1.1>>,traveller}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.6.2.3.yaml
+++ b/concepts/concept-3.6.2.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: driver
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} that is currently responsible
-      for the {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving task}} for the {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} that is currently responsible
+      for the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving task}} for the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}"
   notes:
   - content: The driver is typically on-board the vehicle but could be remote from
       the vehicle or automated logic.

--- a/concepts/concept-3.6.2.4.yaml
+++ b/concepts/concept-3.6.2.4.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: conventional driver
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.6.2.3,driver}} that performs the {{urn:iso:std:iso:14812:3.7.3.1,dynamic
-      driving task}} using the {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicle's}}
-      {{urn:iso:std:iso:14812:3.7.1.5,built-in vehicle input device,built-in input
+  - content: "{{<<urn:iso:std:iso:14812:3.6.2.3>>,driver}} that performs the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
+      driving task}} using the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicle's}}
+      {{<<urn:iso:std:iso:14812:3.7.1.5>>,built-in vehicle input device,built-in input
       devices}} to control the longitudinal and lateral movement of the vehicle"
   notes: []
   examples: []

--- a/concepts/concept-3.6.2.5.yaml
+++ b/concepts/concept-3.6.2.5.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: remote driver
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.6.2.3,driver}} that performs the {{urn:iso:std:iso:14812:3.7.3.1,dynamic
-      driving task}} without using the {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicle's}}
-      {{urn:iso:std:iso:14812:3.7.1.5,built-in vehicle input device,built-in input
+  - content: "{{<<urn:iso:std:iso:14812:3.6.2.3>>,driver}} that performs the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
+      driving task}} without using the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicle's}}
+      {{<<urn:iso:std:iso:14812:3.7.1.5>>,built-in vehicle input device,built-in input
       devices}} to control the longitudinal and lateral movement of the vehicle"
   notes:
   - content: A remote driver can use a variety of physical input devices, but none

--- a/concepts/concept-3.7.1.1.yaml
+++ b/concepts/concept-3.7.1.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.3,material entity}} designed to transport
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} designed to transport
       people or physical goods by changing its physical position"
   notes: []
   examples: []

--- a/concepts/concept-3.7.1.2.yaml
+++ b/concepts/concept-3.7.1.2.yaml
@@ -10,7 +10,7 @@ eng:
     normative_status: admitted
     designation: engine
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.3,material entity}} that converts energy
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that converts energy
       into mechanical motion"
   notes: []
   examples: []

--- a/concepts/concept-3.7.1.3.yaml
+++ b/concepts/concept-3.7.1.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: wheel
   definition:
-  - content: circular {{urn:iso:std:iso:14812:3.1.1.3,material entity}} that rotates
-      about an axle to facilitate movement of the {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: circular {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that rotates
+      about an axle to facilitate movement of the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.1.4.yaml
+++ b/concepts/concept-3.7.1.4.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: input device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.3,material entity}} that can affect the
-      {{urn:iso:std:iso:14812:3.7.1.1,vehicle,vehicle's}} operation"
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}} that can affect the
+      {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle,vehicle's}} operation"
   notes:
   - content: Input devices include those used to control the motion of the vehicle
       (e.g. a brake pedal), the state of vehicular equipment (e.g. headlight control),

--- a/concepts/concept-3.7.1.5.yaml
+++ b/concepts/concept-3.7.1.5.yaml
@@ -10,11 +10,11 @@ eng:
     normative_status: preferred
     designation: built-in input device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.4,vehicle input device,input device}}
-      designed to be physically {{urn:iso:std:iso:14812:3.2.3.6,connected}} to a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.4>>,vehicle input device,input device}}
+      designed to be physically {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} to a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       and to remain connected even when the vehicle is not in use"
   notes:
-  - content: Built-in input devices include devices that can be temporarily {{urn:iso:std:iso:14812:3.7.4.3,disconnected}}
+  - content: Built-in input devices include devices that can be temporarily {{<<urn:iso:std:iso:14812:3.7.4.3>>,disconnected}}
       for security reasons (e.g. some radios are equipped with detachable front panels).
   - content: Built-in input devices are typically considered to be a part of the vehicle.
   - content: Built-in input devices require a maintenance operation to connect or

--- a/concepts/concept-3.7.1.6.yaml
+++ b/concepts/concept-3.7.1.6.yaml
@@ -10,17 +10,17 @@ eng:
     normative_status: preferred
     designation: nomadic input device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.4,vehicle input device,input device}}
-      that can be carried into, or in near proximity of, a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      and {{urn:iso:std:iso:14812:3.2.3.6,connected}} as desired"
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.4>>,vehicle input device,input device}}
+      that can be carried into, or in near proximity of, a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      and {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} as desired"
   notes:
-  - content: NDs are often more closely associated with a {{urn:iso:std:iso:14812:3.1.1.6,person}}
+  - content: NDs are often more closely associated with a {{<<urn:iso:std:iso:14812:3.1.1.6>>,person}}
       than they are with the vehicle.
   - content: Nomadic input devices do not require a maintenance operation to connect
       or disconnect.
   examples:
   - content: A smartphone connected to a vehicle (via USB or Bluetooth) to provide
-      {{urn:iso:std:iso:14812:3.6.2.3,driver}} navigation on the vehicle's large screen
+      {{<<urn:iso:std:iso:14812:3.6.2.3>>,driver}} navigation on the vehicle's large screen
       display
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.7.1.7.yaml
+++ b/concepts/concept-3.7.1.7.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: remote input device
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.4,vehicle input device,input device}}
-      designed to be electronically {{urn:iso:std:iso:14812:3.2.3.6,connected}} to
-      a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} even when the vehicle is not in
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.4>>,vehicle input device,input device}}
+      designed to be electronically {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} to
+      a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} even when the vehicle is not in
       close proximity"
   notes: []
   examples: []

--- a/concepts/concept-3.7.2.1.yaml
+++ b/concepts/concept-3.7.2.1.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: speed
   definition:
-  - content: rate of change of a {{urn:iso:std:iso:14812:3.1.1.3,material entity,material
+  - content: rate of change of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity,material
       entity's}} position with respect to a frame of reference
   notes:
   - content: Speed is a function of time.

--- a/concepts/concept-3.7.2.2.yaml
+++ b/concepts/concept-3.7.2.2.yaml
@@ -14,7 +14,7 @@ eng:
     designation: top speed
   domain: vehicle
   definition:
-  - content: maximum {{urn:iso:std:iso:14812:3.7.2.1,speed}} at which a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: maximum {{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} at which a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       is intended to operate for a sustained period of time
   notes:
   - content: The term "top speed" is defined in <<SAE_J3194,SAE J3194>> in relation

--- a/concepts/concept-3.7.3.1.yaml
+++ b/concepts/concept-3.7.3.1.yaml
@@ -11,10 +11,10 @@ eng:
     designation: DDT
   definition:
   - content: all real-time operational and tactical functions required to operate
-      a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} in on-road traffic
+      a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} in on-road traffic
   notes:
   - content: The DDT includes lateral vehicle motion control, longitudinal vehicle
-      motion control, monitoring the driving {{urn:iso:std:iso:14812:3.1.3.11,environment}},
+      motion control, monitoring the driving {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment}},
       object and event response execution, manoeuvre planning and enhancing conspicuity.
   - content: The DDT excludes strategic functions such as trip scheduling and selection
       of destinations and waypoints.

--- a/concepts/concept-3.7.3.10.yaml
+++ b/concepts/concept-3.7.3.10.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: Automated Driving System
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.6,driving automation system}} that is
-      able to perform the entire {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving task,DDT}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.6>>,driving automation system}} that is
+      able to perform the entire {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving task,DDT}}
       on a sustained basis"
   notes:
   - content: The abbreviated form ("ADS") is the most preferred form and the alternative

--- a/concepts/concept-3.7.3.11.yaml
+++ b/concepts/concept-3.7.3.11.yaml
@@ -13,17 +13,17 @@ eng:
     normative_status: preferred
     designation: level 3 Automated Driving System
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.10,ADS}} designed with the expectation
-      that the {{urn:iso:std:iso:14812:3.7.3.4,fallback-ready user}} is available
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}} designed with the expectation
+      that the {{<<urn:iso:std:iso:14812:3.7.3.4>>,fallback-ready user}} is available
       to intervene"
   notes:
-  - content: Level 3 ADSs are restricted to operating within a specific {{urn:iso:std:iso:14812:3.7.3.2,operational
+  - content: Level 3 ADSs are restricted to operating within a specific {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational
       design domain,ODD}}.
-  - content: Other driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.9,level 2 driving automation}}",
-      "{{urn:iso:std:iso:14812:3.7.3.12,level 4 ADS}}", and "{{urn:iso:std:iso:14812:3.7.3.13,level
+  - content: Other driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.9>>,level 2 driving automation}}",
+      "{{<<urn:iso:std:iso:14812:3.7.3.12>>,level 4 ADS}}", and "{{<<urn:iso:std:iso:14812:3.7.3.13>>,level
       5 ADS}}".
-  - content: The user can intervene due to an ADS-issued request, a {{urn:iso:std:iso:14812:3.7.3.1,dynamic
+  - content: The user can intervene due to an ADS-issued request, a {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
       driving task,DDT}} performance-relevant system failure, or other reasons.
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.12.yaml
+++ b/concepts/concept-3.7.3.12.yaml
@@ -13,15 +13,15 @@ eng:
     normative_status: preferred
     designation: level 4 Automated Driving System
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.10,ADS}} that is capable of operating
-      within a specific {{urn:iso:std:iso:14812:3.7.3.2,operational design domain,ODD}}
-      and providing its own {{urn:iso:std:iso:14812:3.7.3.3,fallback}}, without any
-      expectation that a human {{urn:iso:std:iso:14812:3.6.2.3,driver}} will respond
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}} that is capable of operating
+      within a specific {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational design domain,ODD}}
+      and providing its own {{<<urn:iso:std:iso:14812:3.7.3.3>>,fallback}}, without any
+      expectation that a human {{<<urn:iso:std:iso:14812:3.6.2.3>>,driver}} will respond
       to a request to intervene"
   notes:
-  - content: Other driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.9,level 2 driving automation}}",
-      "{{urn:iso:std:iso:14812:3.7.3.11,level 3 ADS}}", and "{{urn:iso:std:iso:14812:3.7.3.13,level
+  - content: Other driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.9>>,level 2 driving automation}}",
+      "{{<<urn:iso:std:iso:14812:3.7.3.11>>,level 3 ADS}}", and "{{<<urn:iso:std:iso:14812:3.7.3.13>>,level
       5 ADS}}".
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.13.yaml
+++ b/concepts/concept-3.7.3.13.yaml
@@ -13,15 +13,15 @@ eng:
     normative_status: preferred
     designation: level 5 Automated Driving System
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.10,ADS}} that is capable of unconditional
-      (i.e. not {{urn:iso:std:iso:14812:3.7.3.2,operational design domain,ODD}}-specific)
-      operation and providing its own {{urn:iso:std:iso:14812:3.7.3.3,fallback}},
-      without any expectation that a human {{urn:iso:std:iso:14812:3.6.2.3,driver}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}} that is capable of unconditional
+      (i.e. not {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational design domain,ODD}}-specific)
+      operation and providing its own {{<<urn:iso:std:iso:14812:3.7.3.3>>,fallback}},
+      without any expectation that a human {{<<urn:iso:std:iso:14812:3.6.2.3>>,driver}}
       will respond to a request to intervene"
   notes:
-  - content: Other driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.9,level 2 driving automation}}",
-      "{{urn:iso:std:iso:14812:3.7.3.11,level 3 ADS}}" and "{{urn:iso:std:iso:14812:3.7.3.12,level
+  - content: Other driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.9>>,level 2 driving automation}}",
+      "{{<<urn:iso:std:iso:14812:3.7.3.11>>,level 3 ADS}}" and "{{<<urn:iso:std:iso:14812:3.7.3.12>>,level
       4 ADS}}".
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.14.yaml
+++ b/concepts/concept-3.7.3.14.yaml
@@ -11,8 +11,8 @@ eng:
     designation: automation-equipped conventional vehicle
   domain: driving automation
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} designed to be operated by
-      a {{urn:iso:std:iso:14812:3.1.1.6,person}} during part or all of every _trip_."
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} designed to be operated by
+      a {{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} during part or all of every _trip_."
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.15.yaml
+++ b/concepts/concept-3.7.3.15.yaml
@@ -16,7 +16,7 @@ eng:
     normative_status: deprecated
     designation: autonomous vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} integrated with an {{urn:iso:std:iso:14812:3.7.3.10,ADS}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} integrated with an {{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}}"
   notes:
   - content: The terms "automated vehicle" and "AV" are often used in a colloquial
       form. However, these terms can be used to mean either an "ADS-equipped vehicle"
@@ -25,17 +25,17 @@ eng:
   - content: The term "autonomous vehicle" is also often used in a colloquial form
       and is even less well defined. The term is particularly problematic because
       the word "autonomous" has been used for a long time in the robotics and artificial
-      intelligence research communities to signify {{urn:iso:std:iso:14812:3.1.2.1,system,systems}}
+      intelligence research communities to signify {{<<urn:iso:std:iso:14812:3.1.2.1>>,system,systems}}
       that have the ability and authority to make decisions independently and self-sufficiently.
       Due to its imprecise and overly broad meaning, use of the term "autonomous vehicle"
       is discouraged.
   - content: This term can be, and when possible should be, refined by identifying
       the level of automation. For example, the terms "level 5 ADS-equipped vehicle"
       and "level 5 automated vehicle" should be interpreted as "ADS-equipped vehicle
-      where the ADS is a {{urn:iso:std:iso:14812:3.7.3.13,level 5 ADS}}".
+      where the ADS is a {{<<urn:iso:std:iso:14812:3.7.3.13>>,level 5 ADS}}".
   - content: This term only describes the capabilities of the vehicle, not its operational
-      state. In other words, the term applies as long as the ADS is {{urn:iso:std:iso:14812:3.2.3.6,connected}}
-      to the vehicle, whether the {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving
+      state. In other words, the term applies as long as the ADS is {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}}
+      to the vehicle, whether the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving
       task,DDT}} is actively engaged or not.
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.16.yaml
+++ b/concepts/concept-3.7.3.16.yaml
@@ -11,8 +11,8 @@ eng:
     designation: driving automation dual-mode vehicle
   domain: driving automation
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.15,ADS-equipped vehicle}} designed for
-      both driverless operation and operation by a {{urn:iso:std:iso:14812:3.6.2.4,in-vehicle
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.15>>,ADS-equipped vehicle}} designed for
+      both driverless operation and operation by a {{<<urn:iso:std:iso:14812:3.6.2.4>>,in-vehicle
       driver,conventional driver}} for complete _trips_"
   notes: []
   examples: []

--- a/concepts/concept-3.7.3.17.yaml
+++ b/concepts/concept-3.7.3.17.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: ADS-dedicated vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.15,ADS-equipped vehicle}} designed for
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.15>>,ADS-equipped vehicle}} designed for
       only driverless operation for complete trips"
   notes: []
   examples: []

--- a/concepts/concept-3.7.3.2.yaml
+++ b/concepts/concept-3.7.3.2.yaml
@@ -10,17 +10,17 @@ eng:
     normative_status: preferred
     designation: ODD
   definition:
-  - content: set of operating conditions under which a given {{urn:iso:std:iso:14812:3.7.3.6,driving
+  - content: set of operating conditions under which a given {{<<urn:iso:std:iso:14812:3.7.3.6>>,driving
       automation system}} or feature thereof is specifically designed to function
   notes:
   - content: The conditions can include environmental, geographical, time-of-day,
       and/or other restrictions.
   - content: The conditions can require the presence or absence of certain traffic
-      or {{urn:iso:std:iso:14812:3.3.1.3,roadway}} characteristics.
+      or {{<<urn:iso:std:iso:14812:3.3.1.3>>,roadway}} characteristics.
   examples:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.10,ADS}} feature designed to operate a
-      {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} only on fully access-controlled freeways
-      in low-speed traffic, under fair weather conditions and optimal {{urn:iso:std:iso:14812:3.3.5.1,road}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}} feature designed to operate a
+      {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} only on fully access-controlled freeways
+      in low-speed traffic, under fair weather conditions and optimal {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}
       maintenance conditions (e.g. good lane markings and not under construction)."
   - content: ADS-dedicated vehicle designed to operate only within a geographically-defined
       area, and only during daylight at speeds not exceeding 25 mph.

--- a/concepts/concept-3.7.3.3.yaml
+++ b/concepts/concept-3.7.3.3.yaml
@@ -11,11 +11,11 @@ eng:
     designation: driving automation fallback
   domain: driving automation
   definition:
-  - content: response by a {{urn:iso:std:iso:14812:3.1.1.6,person}} to perform the
-      {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving task,DDT}} or by an {{urn:iso:std:iso:14812:3.7.3.10,ADS}}
+  - content: response by a {{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} to perform the
+      {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving task,DDT}} or by an {{<<urn:iso:std:iso:14812:3.7.3.10>>,ADS}}
       to achieve a minimal risk condition when the response is triggered upon violation
-      of the defined {{urn:iso:std:iso:14812:3.7.3.2,operational design domain}} constraints
-      or in response to a DDT performance-relevant {{urn:iso:std:iso:14812:3.7.3.6,driving
+      of the defined {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational design domain}} constraints
+      or in response to a DDT performance-relevant {{<<urn:iso:std:iso:14812:3.7.3.6>>,driving
       automation system}} failure
   notes:
   - content: This term includes the response of a person to perform the DDT in a manner

--- a/concepts/concept-3.7.3.4.yaml
+++ b/concepts/concept-3.7.3.4.yaml
@@ -11,10 +11,10 @@ eng:
     designation: DDT fallback-ready user
   domain: driving automation
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.1.1.6,person}} who is able to operate the
-      {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} if the Level 3 {{urn:iso:std:iso:14812:3.7.3.11,level
+  - content: "{{<<urn:iso:std:iso:14812:3.1.1.6>>,person}} who is able to operate the
+      {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} if the Level 3 {{<<urn:iso:std:iso:14812:3.7.3.11>>,level
       3 ADS,ADS}} issues a request to intervene or if that person otherwise identifies
-      a condition that requires intervention to perform the {{urn:iso:std:iso:14812:3.7.3.1,dynamic
+      a condition that requires intervention to perform the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
       driving task,DDT}}"
   notes: []
   examples: []

--- a/concepts/concept-3.7.3.5.yaml
+++ b/concepts/concept-3.7.3.5.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: DDT performance-relevant system failure
   definition:
-  - content: malfunction in a {{urn:iso:std:iso:14812:3.2.1.5,vehicle system}} that
-      prevents the {{urn:iso:std:iso:14812:3.7.3.6,driving automation system}} from
-      reliably performing its portion of the {{urn:iso:std:iso:14812:3.7.3.1,dynamic
+  - content: malfunction in a {{<<urn:iso:std:iso:14812:3.2.1.5>>,vehicle system}} that
+      prevents the {{<<urn:iso:std:iso:14812:3.7.3.6>>,driving automation system}} from
+      reliably performing its portion of the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
       driving task,DDT}} on a sustained basis
   notes:
   - content: The malfunction can be internal to the driving automation system or part

--- a/concepts/concept-3.7.3.6.yaml
+++ b/concepts/concept-3.7.3.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: driving automation system
   definition:
-  - content: hardware and software {{urn:iso:std:iso:14812:3.1.2.1,system}} that is
-      able to perform part or all of the {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving
+  - content: hardware and software {{<<urn:iso:std:iso:14812:3.1.2.1>>,system}} that is
+      able to perform part or all of the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving
       task,DDT}} on a sustained basis
   notes:
   - content: In contrast to this generic term for any level 1-5 system, the specific
@@ -21,10 +21,10 @@ eng:
       driving automation.
   - content: Driving automation levels are defined in <<ISO_SAE_22736>>, which is
       also known as <<SAE_J3016,SAE J3016>>.
-  - content: Driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.9,level 2 driving automation}}",
-      "{{urn:iso:std:iso:14812:3.7.3.11,level 3 ADS}}", "{{urn:iso:std:iso:14812:3.7.3.12,level
-      4 ADS}}" and "{{urn:iso:std:iso:14812:3.7.3.13,level 5 ADS}}".
+  - content: Driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.9>>,level 2 driving automation}}",
+      "{{<<urn:iso:std:iso:14812:3.7.3.11>>,level 3 ADS}}", "{{<<urn:iso:std:iso:14812:3.7.3.12>>,level
+      4 ADS}}" and "{{<<urn:iso:std:iso:14812:3.7.3.13>>,level 5 ADS}}".
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.7.3.7.yaml
+++ b/concepts/concept-3.7.3.7.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: driver support system
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.6,driving automation system}} that is
-      only able to perform part of the {{urn:iso:std:iso:14812:3.7.3.1,dynamic driving
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.6>>,driving automation system}} that is
+      only able to perform part of the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic driving
       task,DDT}}"
   notes:
-  - content: Driver support systems include {{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation,level 1}} and {{urn:iso:std:iso:14812:3.7.3.9,level 2 driving
+  - content: Driver support systems include {{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation,level 1}} and {{<<urn:iso:std:iso:14812:3.7.3.9>>,level 2 driving
       automation}}.
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.3.8.yaml
+++ b/concepts/concept-3.7.3.8.yaml
@@ -10,16 +10,16 @@ eng:
     normative_status: preferred
     designation: driver assistance
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.7,driver support system}} that provides
-      either sustained lateral or sustained longitudinal {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      motion control within a specific {{urn:iso:std:iso:14812:3.7.3.2,operational
-      design domain}} with the expectation that a {{urn:iso:std:iso:14812:3.6.2.4,in-vehicle
-      driver,conventional driver}} completes the {{urn:iso:std:iso:14812:3.7.3.1,dynamic
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.7>>,driver support system}} that provides
+      either sustained lateral or sustained longitudinal {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      motion control within a specific {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational
+      design domain}} with the expectation that a {{<<urn:iso:std:iso:14812:3.6.2.4>>,in-vehicle
+      driver,conventional driver}} completes the {{<<urn:iso:std:iso:14812:3.7.3.1>>,dynamic
       driving task,DDT}}"
   notes:
-  - content: Other driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.9,level
-      2 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.11,level 3 ADS}}", "{{urn:iso:std:iso:14812:3.7.3.12,level
-      4 ADS}}", and "{{urn:iso:std:iso:14812:3.7.3.13,level 5 ADS}}".
+  - content: Other driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.9>>,level
+      2 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.11>>,level 3 ADS}}", "{{<<urn:iso:std:iso:14812:3.7.3.12>>,level
+      4 ADS}}", and "{{<<urn:iso:std:iso:14812:3.7.3.13>>,level 5 ADS}}".
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.7.3.9.yaml
+++ b/concepts/concept-3.7.3.9.yaml
@@ -10,15 +10,15 @@ eng:
     normative_status: preferred
     designation: partial driving automation
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.3.7,driver support system}} that provides
-      sustained lateral and longitudinal {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      motion control within a specific {{urn:iso:std:iso:14812:3.7.3.2,operational
-      design domain}} with the expectation that a {{urn:iso:std:iso:14812:3.6.2.4,in-vehicle
+  - content: "{{<<urn:iso:std:iso:14812:3.7.3.7>>,driver support system}} that provides
+      sustained lateral and longitudinal {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      motion control within a specific {{<<urn:iso:std:iso:14812:3.7.3.2>>,operational
+      design domain}} with the expectation that a {{<<urn:iso:std:iso:14812:3.6.2.4>>,in-vehicle
       driver,conventional driver}} completes the object and event detection and response"
   notes:
-  - content: Other driving automation levels include "{{urn:iso:std:iso:14812:3.7.3.8,level
-      1 driving automation}}", "{{urn:iso:std:iso:14812:3.7.3.11,level 3 ADS}}", "{{urn:iso:std:iso:14812:3.7.3.12,level
-      4 ADS}}", and "{{urn:iso:std:iso:14812:3.7.3.13,level 5 ADS}}".
+  - content: Other driving automation levels include "{{<<urn:iso:std:iso:14812:3.7.3.8>>,level
+      1 driving automation}}", "{{<<urn:iso:std:iso:14812:3.7.3.11>>,level 3 ADS}}", "{{<<urn:iso:std:iso:14812:3.7.3.12>>,level
+      4 ADS}}", and "{{<<urn:iso:std:iso:14812:3.7.3.13>>,level 5 ADS}}".
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.7.4.1.yaml
+++ b/concepts/concept-3.7.4.1.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: preferred
     designation: ITS off-grid
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}}
-      that is currently unable to send data to or receive data from {{urn:iso:std:iso:14812:3.2.3.6,connected}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}}
+      that is currently unable to send data to or receive data from {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}}
       entities
   notes: []
   examples: []

--- a/concepts/concept-3.7.4.2.yaml
+++ b/concepts/concept-3.7.4.2.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: ITS unconnected
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}}
       that is equipped with communications equipment that is not active or is otherwise
-      unable to send data to or receive data from {{urn:iso:std:iso:14812:3.2.3.6,connected}}
+      unable to send data to or receive data from {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}}
       entities
   notes: []
   examples: []

--- a/concepts/concept-3.7.4.3.yaml
+++ b/concepts/concept-3.7.4.3.yaml
@@ -10,12 +10,12 @@ eng:
     normative_status: preferred
     designation: ITS disconnected
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}}
       that is or was equipped with communications equipment that is sufficiently physically
       disconnected such that the material entity is no longer able to send data to
-      or receive data from {{urn:iso:std:iso:14812:3.2.3.6,connected}} entities
+      or receive data from {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} entities
   notes:
-  - content: The vehicle on-board equipment can still be present in the {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: The vehicle on-board equipment can still be present in the {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       and can even be partially connected, but not in any operational sense.
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.4.4.yaml
+++ b/concepts/concept-3.7.4.4.yaml
@@ -10,9 +10,9 @@ eng:
     normative_status: preferred
     designation: ITS unequipped
   definition:
-  - content: characteristic of a {{urn:iso:std:iso:14812:3.1.1.3,material entity}}
+  - content: characteristic of a {{<<urn:iso:std:iso:14812:3.1.1.3>>,material entity}}
       that is not and has never been equipped with communications equipment for sending
-      data to or receiving data from {{urn:iso:std:iso:14812:3.2.3.6,connected}} entities
+      data to or receiving data from {{<<urn:iso:std:iso:14812:3.2.3.6>>,connected}} entities
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.5.1.yaml
+++ b/concepts/concept-3.7.5.1.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: admitted
     designation: pedestrian-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} that does not exceed {{urn:iso:std:iso:14812:3.7.5.7,ultra-low vehicle
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} that does not exceed {{<<urn:iso:std:iso:14812:3.7.5.7>>,ultra-low vehicle
       speed,ultra-low vehicle speeds}}"
   notes:
   - content: The term "pedestrian speed vehicle" is allowed but the preferred term

--- a/concepts/concept-3.7.5.10.yaml
+++ b/concepts/concept-3.7.5.10.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: moderate vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      that exceeds {{urn:iso:std:iso:14812:3.7.5.9,moderately-low vehicle speed,moderately-low
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      that exceeds {{<<urn:iso:std:iso:14812:3.7.5.9>>,moderately-low vehicle speed,moderately-low
       vehicle speeds}} but does not reach free-flow motorway speeds"
   notes:
   - content: Local regulations for the exact speed range vary.

--- a/concepts/concept-3.7.5.11.yaml
+++ b/concepts/concept-3.7.5.11.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: moderately-high vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       that is typical of free-flow motorway speeds to twice that speed"
   notes:
   - content: Local regulations for the exact speed range vary.

--- a/concepts/concept-3.7.5.12.yaml
+++ b/concepts/concept-3.7.5.12.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: high vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       that exceeds free flow motorway speeds by a factor of two or more"
   notes:
   - content: Local regulations for the exact speed range vary.

--- a/concepts/concept-3.7.5.2.yaml
+++ b/concepts/concept-3.7.5.2.yaml
@@ -10,8 +10,8 @@ eng:
     normative_status: admitted
     designation: cycle-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} in the range of {{urn:iso:std:iso:14812:3.7.5.8,low vehicle speed,low
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} in the range of {{<<urn:iso:std:iso:14812:3.7.5.8>>,low vehicle speed,low
       vehicle speeds}}"
   notes:
   - content: The term "cycle-speed vehicle" is allowed but the preferred term follows

--- a/concepts/concept-3.7.5.3.yaml
+++ b/concepts/concept-3.7.5.3.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: moderately low-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} in the range of {{urn:iso:std:iso:14812:3.7.5.9,moderately-low vehicle
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} in the range of {{<<urn:iso:std:iso:14812:3.7.5.9>>,moderately-low vehicle
       speed,moderately-low vehicle speeds}}"
   notes: []
   examples:

--- a/concepts/concept-3.7.5.4.yaml
+++ b/concepts/concept-3.7.5.4.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: moderate-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} in the range of {{urn:iso:std:iso:14812:3.7.5.10,moderate vehicle speed,moderate
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} in the range of {{<<urn:iso:std:iso:14812:3.7.5.10>>,moderate vehicle speed,moderate
       vehicle speeds}}"
   notes: []
   examples:

--- a/concepts/concept-3.7.5.5.yaml
+++ b/concepts/concept-3.7.5.5.yaml
@@ -7,12 +7,12 @@ eng:
     normative_status: preferred
     designation: moderately high-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} in the range of {{urn:iso:std:iso:14812:3.7.5.11,moderately-high vehicle
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} in the range of {{<<urn:iso:std:iso:14812:3.7.5.11>>,moderately-high vehicle
       speed,moderately-high vehicle speeds}}"
   notes: []
   examples:
-  - content: Typical {{urn:iso:std:iso:14812:3.6.2.1,passenger}} car.
+  - content: Typical {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger}} car.
   language_code: eng
   entry_status: valid
   sources:

--- a/concepts/concept-3.7.5.6.yaml
+++ b/concepts/concept-3.7.5.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: high-speed vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} with a {{urn:iso:std:iso:14812:3.7.2.2,design
-      speed}} in the range of {{urn:iso:std:iso:14812:3.7.5.12,high vehicle speed,high
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} with a {{<<urn:iso:std:iso:14812:3.7.2.2>>,design
+      speed}} in the range of {{<<urn:iso:std:iso:14812:3.7.5.12>>,high vehicle speed,high
       vehicle speeds}}"
   notes: []
   examples:

--- a/concepts/concept-3.7.5.7.yaml
+++ b/concepts/concept-3.7.5.7.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: ultra-low vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      that does not greatly exceed typical {{urn:iso:std:iso:14812:3.6.1.3,pedestrian}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      that does not greatly exceed typical {{<<urn:iso:std:iso:14812:3.6.1.3>>,pedestrian}}
       speeds"
   notes:
   - content: Local regulations for the exact speed range vary.

--- a/concepts/concept-3.7.5.8.yaml
+++ b/concepts/concept-3.7.5.8.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: low vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
-      that exceeds {{urn:iso:std:iso:14812:3.6.1.3,pedestrian}} speeds and is more
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
+      that exceeds {{<<urn:iso:std:iso:14812:3.6.1.3>>,pedestrian}} speeds and is more
       typical of pedal cycles"
   notes:
   - content: Local regulations for the exact speed range vary.

--- a/concepts/concept-3.7.5.9.yaml
+++ b/concepts/concept-3.7.5.9.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: moderately-low vehicle speed
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.2.1,speed}} of a {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.2.1>>,speed}} of a {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
       that exceeds speeds typical of pedal cycles but can be reached on performance
       pedal cycles in short bursts or by performance riders"
   notes:

--- a/concepts/concept-3.7.6.1.yaml
+++ b/concepts/concept-3.7.6.1.yaml
@@ -7,14 +7,14 @@ eng:
     normative_status: preferred
     designation: road vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} meeting the requirements to
-      operate within the {{urn:iso:std:iso:14812:3.3.1.4,driving space}} of a {{urn:iso:std:iso:14812:3.3.5.1,road}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} meeting the requirements to
+      operate within the {{<<urn:iso:std:iso:14812:3.3.1.4>>,driving space}} of a {{<<urn:iso:std:iso:14812:3.3.5.1>>,road}}"
   notes:
   - content: Unless indicated otherwise, the term typically refers to vehicles that
-      are allowed to operate in the same driving spaces as motorized {{urn:iso:std:iso:14812:3.6.2.1,passenger}}
-      cars, according to the legal requirements of the local jurisdictional {{urn:iso:std:iso:14812:3.1.1.1,entity}}.
-      However, the term can be contextualized for other {{urn:iso:std:iso:14812:3.1.3.11,environment,environments}}.
-      For example, a bicycle is a "road vehicle" when the "road" is a {{urn:iso:std:iso:14812:3.3.3.2,cycleway}}.
+      are allowed to operate in the same driving spaces as motorized {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger}}
+      cars, according to the legal requirements of the local jurisdictional {{<<urn:iso:std:iso:14812:3.1.1.1>>,entity}}.
+      However, the term can be contextualized for other {{<<urn:iso:std:iso:14812:3.1.3.11>>,environment,environments}}.
+      For example, a bicycle is a "road vehicle" when the "road" is a {{<<urn:iso:std:iso:14812:3.3.3.2>>,cycleway}}.
   examples: []
   language_code: eng
   entry_status: valid

--- a/concepts/concept-3.7.6.2.yaml
+++ b/concepts/concept-3.7.6.2.yaml
@@ -7,7 +7,7 @@ eng:
     normative_status: preferred
     designation: motorized vehicle
   definition:
-  - content: self-propelled {{urn:iso:std:iso:14812:3.7.1.1,vehicle}}
+  - content: self-propelled {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}}
   notes: []
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.6.3.yaml
+++ b/concepts/concept-3.7.6.3.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: motor vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.6.2,motorized vehicle,motorized}} {{urn:iso:std:iso:14812:3.7.6.1,road
-      vehicle}} allowed to operate in the same {{urn:iso:std:iso:14812:3.3.1.4,driving
-      space,driving spaces}} as motorized {{urn:iso:std:iso:14812:3.6.2.1,passenger}}
+  - content: "{{<<urn:iso:std:iso:14812:3.7.6.2>>,motorized vehicle,motorized}} {{<<urn:iso:std:iso:14812:3.7.6.1>>,road
+      vehicle}} allowed to operate in the same {{<<urn:iso:std:iso:14812:3.3.1.4>>,driving
+      space,driving spaces}} as motorized {{<<urn:iso:std:iso:14812:3.6.2.1>>,passenger}}
       cars"
   notes: []
   examples: []

--- a/concepts/concept-3.7.6.4.yaml
+++ b/concepts/concept-3.7.6.4.yaml
@@ -7,9 +7,9 @@ eng:
     normative_status: preferred
     designation: non-road vehicle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} not meeting the legal requirements
-      to be driven in {{urn:iso:std:iso:14812:3.3.1.13,traffic lane,traffic lanes}}
-      or {{urn:iso:std:iso:14812:3.3.3.1,cycle lane,cycle lanes}} of a {{urn:iso:std:iso:14812:3.3.5.2,road
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} not meeting the legal requirements
+      to be driven in {{<<urn:iso:std:iso:14812:3.3.1.13>>,traffic lane,traffic lanes}}
+      or {{<<urn:iso:std:iso:14812:3.3.3.1>>,cycle lane,cycle lanes}} of a {{<<urn:iso:std:iso:14812:3.3.5.2>>,road
       network}}"
   notes: []
   examples: []

--- a/concepts/concept-3.7.6.5.yaml
+++ b/concepts/concept-3.7.6.5.yaml
@@ -7,10 +7,10 @@ eng:
     normative_status: preferred
     designation: road cycle
   definition:
-  - content: "{{urn:iso:std:iso:14812:3.7.1.1,vehicle}} meeting the legal requirements
-      to operate in {{urn:iso:std:iso:14812:3.3.3.1,cycle lane,cycle lanes}} and {{urn:iso:std:iso:14812:3.3.3.2,cycleway,cycleways}}"
+  - content: "{{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} meeting the legal requirements
+      to operate in {{<<urn:iso:std:iso:14812:3.3.3.1>>,cycle lane,cycle lanes}} and {{<<urn:iso:std:iso:14812:3.3.3.2>>,cycleway,cycleways}}"
   notes:
-  - content: In some countries, other special {{urn:iso:std:iso:14812:3.3.1.13,lane,lanes}}
+  - content: In some countries, other special {{<<urn:iso:std:iso:14812:3.3.1.13>>,lane,lanes}}
       could also be open to road cycles, such as bus lanes.
   examples: []
   language_code: eng

--- a/concepts/concept-3.7.6.6.yaml
+++ b/concepts/concept-3.7.6.6.yaml
@@ -7,8 +7,8 @@ eng:
     normative_status: preferred
     designation: non-road cycle
   definition:
-  - content: human-powered {{urn:iso:std:iso:14812:3.7.1.1,vehicle}} not meeting the
-      legal requirements to be driven in {{urn:iso:std:iso:14812:3.3.3.1,cycle lane,cycle
+  - content: human-powered {{<<urn:iso:std:iso:14812:3.7.1.1>>,vehicle}} not meeting the
+      legal requirements to be driven in {{<<urn:iso:std:iso:14812:3.3.3.1>>,cycle lane,cycle
       lanes}}
   notes: []
   examples: []


### PR DESCRIPTION
Updated references to use the metanorma syntax for anchors.

for https://github.com/metanorma/metanorma-plugin-glossarist/pull/35