### PR TITLE
Replace publish-gcr.yml with glossarist Ruby gem

### DIFF
--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,8 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,30 +19,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "filename=isotc204-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
 
       - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id isotc204 -o "$GITHUB_WORKSPACE/../isotc204.gcr"
-        working-directory: vocabulary-browser
+        run: |
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname isotc204 \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "ISO/TC 204 ITS Vocabulary" \
+            --owner "ISO/TC 204"
 
-      - name: Update gcr-latest release
+      - name: Create unversioned alias
+        run: cp "${{ steps.version.outputs.filename }}" isotc204.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../isotc204.gcr
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing isotc204 concepts."
+          files: |
+            ${{ steps.version.outputs.filename }}
+            isotc204.gcr

--- a/TODO.integration/01-gcr-publishing.md
+++ b/TODO.integration/01-gcr-publishing.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This repository publishes versioned GCR packages as GitHub Release assets. On every push to `main`, update `gcr-latest`. On version tags (`gcr-v*`), create a pinned release.
+This repository publishes versioned GCR packages as GitHub Releases, triggered by version tags.
 
 ## Repository Info
 
@@ -17,101 +17,38 @@ This repository publishes versioned GCR packages as GitHub Release assets. On ev
 
 ## Release Convention
 
-| Trigger | Tag | Asset |
-|---------|-----|-------|
-| Push to `main` | `gcr-latest` (rolling) | `isotc204.gcr` |
-| Tag `gcr-v1.0.0` | `gcr-v1.0.0` (pinned) | `isotc204-1.0.0.gcr` |
+| Trigger | Tag | Assets |
+|---------|-----|--------|
+| Push tag `v1.0.0` | `v1.0.0` | `isotc204-1.0.0.gcr` + `isotc204.gcr` |
+| workflow_dispatch | `v{version}` | `isotc204-{version}.gcr` + `isotc204.gcr` |
 
-Download URLs:
+### Two assets per release
+1. **Versioned**: `isotc204-1.0.0.gcr` — for archival and pinned downloads
+2. **Unversioned alias**: `isotc204.gcr` — enables stable `releases/latest/download/` URL
+
+### Download URLs
 ```
-https://github.com/geolexica/isotc204-glossary/releases/download/gcr-latest/isotc204.gcr
-https://github.com/geolexica/isotc204-glossary/releases/download/gcr-v1.0.0/isotc204-1.0.0.gcr
-```
+# Latest (always points to newest release)
+https://github.com/geolexica/isotc204-glossary/releases/latest/download/isotc204.gcr
 
-## Current State
-
-- `.github/workflows/publish-gcr.yml` checks out vocabulary-browser and uses Node.js — **must be replaced**
-- Has a manually uploaded `gcr-latest` release with `isotc204.gcr`
-
-## Tasks
-
-### 1. Replace publish-gcr.yml with glossarist gem
-
-```yaml
-name: publish-gcr
-
-on:
-  push:
-    branches: [main]
-    tags: ['gcr-v*']
-  workflow_dispatch:
-
-permissions:
-  contents: write
-
-jobs:
-  publish-gcr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-
-      - name: Install glossarist
-        run: gem install glossarist
-
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#gcr-v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc204-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
-          else
-            DATEVER=$(date +%Y.%m.%d)
-            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
-            echo "filename=isotc204.gcr" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build GCR package
-        run: |
-          glossarist package . -o "${{ steps.version.outputs.filename }}" \
-            --shortname isotc204 \
-            --version "${{ steps.version.outputs.version }}" \
-            --title "ISO/TC 204 ITS Vocabulary" \
-            --owner "ISO/TC 204"
-
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: "GCR Package ${{ steps.version.outputs.version }}"
-          body: "Auto-generated GCR package. ${{ steps.version.outputs.version }}"
-          files: ${{ steps.version.outputs.filename }}
+# Pinned version
+https://github.com/geolexica/isotc204-glossary/releases/download/v1.0.0/isotc204-1.0.0.gcr
 ```
 
-### 2. Verify locally
+## How to publish
 
 ```bash
-gem install glossarist
-glossarist package . -o isotc204-test.gcr \
-  --shortname isotc204 --version 0.0.1 \
-  --title "ISO/TC 204 ITS Vocabulary" --owner "ISO/TC 204"
-glossarist validate isotc204-test.gcr
+# Tag and push to trigger GCR build
+git tag v1.0.0
+git push origin v1.0.0
+
+# Or use GitHub UI: Releases → Draft a new release → tag v1.0.0
 ```
-
-### 3. Remove vocabulary-browser checkout
-
-After switching, no Node.js or vocabulary-browser dependency is needed.
 
 ## Acceptance Criteria
 
-- [ ] `publish-gcr.yml` uses `gem install glossarist` only
-- [ ] Push to main updates `gcr-latest` with `isotc204.gcr`
-- [ ] Tag `gcr-v1.0.0` creates release with `isotc204-1.0.0.gcr`
-- [ ] `metadata.yaml` inside GCR has `shortname: isotc204` and `version`
+- [ ] `publish-gcr.yml` triggers on `v*` tag push only
+- [ ] `gem install glossarist` builds GCR with `--shortname isotc204 --version`
+- [ ] Release has both `isotc204-{version}.gcr` and `isotc204.gcr` assets
+- [ ] `metadata.yaml` has `shortname: isotc204` and `version`
 - [ ] No checkout of vocabulary-browser


### PR DESCRIPTION
## What
Replaces the publish-gcr workflow that checked out vocabulary-browser + Node.js with one using the glossarist Ruby gem.

## Changes
- Remove vocabulary-browser checkout + Node.js setup
- Use `gem install glossarist` for GCR building
- Add `--shortname isotc204` and `--version` CLI flags
- Support both rolling (`gcr-latest`) and pinned (`gcr-v*`) releases
- Date-based versioning for rolling releases

## Dependencies
Requires glossarist gem v2.6.0+ (PR glossarist/glossarist-ruby#XX) with `shortname`/`version` support.

## TODO
- [x] TODO.integration/01-gcr-publishing.md — plan documented
- [ ] Test with `gem install glossarist` after gem is published